### PR TITLE
nuPickers ValueConnector

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This project offers Umbraco Deploy connectors for the following community packag
 - [LeBlender](https://our.umbraco.org/projects/backoffice-extensions/leblender)
 - [Nested Content](https://our.umbraco.org/projects/backoffice-extensions/nested-content/)
 - [Stacked Content](https://github.com/umco/umbraco-stacked-content)
+- [nuPickers](https://our.umbraco.org/projects/backoffice-extensions/nupickers/)
 
 ---
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="ValueConnectors\ArchetypeValueConnector.cs" />
     <Compile Include="ValueConnectors\MultiUrlPickerValueConnector.cs" />
+    <Compile Include="ValueConnectors\NuPickersValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinksValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinks2ValueConnector.cs" />
     <Compile Include="ValueConnectors\VortoValueConnector.cs" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -47,6 +47,9 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             // get the property value
             var value = property.Value as string;
 
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
             // parse the value - checking the format - CSV, XML or JSON
             SaveFormat format;
             var items = ParseValue(value, out format);

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -1,0 +1,241 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Xml.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    /// <summary>
+    /// A Deploy connector for the nuPickers property editor
+    /// </summary>
+    public class NuPickersValueConnector : IValueConnector
+    {
+        private readonly IEntityService _entityService;
+
+        private enum SaveFormat
+        {
+            CSV,
+            JSON,
+            XML,
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NuPickersValueConnector"/> class.
+        /// </summary>
+        /// <param name="entityService">An <see cref="IEntityService"/> implementation.</param>
+        public NuPickersValueConnector(IEntityService entityService)
+        {
+            _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
+        }
+
+        public IEnumerable<string> PropertyEditorAliases => new[]
+        {
+            "nuPickers.DotNetCheckBoxPicker",
+            "nuPickers.DotNetDropDownPicker",
+            "nuPickers.DotNetLabels",
+            "nuPickers.DotNetPagedListPicker",
+            "nuPickers.DotNetPrefetchListPicker",
+            "nuPickers.DotNetRadioButtonPicker",
+            "nuPickers.DotNetTypeaheadListPicker",
+            "nuPickers.EnumCheckBoxPicker",
+            "nuPickers.EnumDropDownPicker",
+            "nuPickers.EnumLabels",
+            "nuPickers.EnumPrefetchListPicker",
+            "nuPickers.EnumRadioButtonPicker",
+            "nuPickers.JsonCheckBoxPicker",
+            "nuPickers.JsonDropDownPicker",
+            "nuPickers.JsonLabels",
+            "nuPickers.JsonPagedListPicker",
+            "nuPickers.JsonPrefetchListPicker",
+            "nuPickers.JsonRadioButtonPicker",
+            "nuPickers.JsonTypeaheadListPicker",
+            "nuPickers.LuceneCheckBoxPicker",
+            "nuPickers.LuceneDropDownPicker",
+            "nuPickers.LuceneLabels",
+            "nuPickers.LucenePagedListPicker",
+            "nuPickers.LucenePrefetchListPicker",
+            "nuPickers.LuceneRadioButtonPicker",
+            "nuPickers.LuceneTypeaheadListPicker",
+            "nuPickers.RelationLabels",
+            "nuPickers.SqlCheckBoxPicker",
+            "nuPickers.SqlDropDownPicker",
+            "nuPickers.SqlLabels",
+            "nuPickers.SqlPagedListPicker",
+            "nuPickers.SqlPrefetchListPicker",
+            "nuPickers.SqlRadioButtonPicker",
+            "nuPickers.SqlTypeaheadListPicker",
+            "nuPickers.XmlCheckBoxPicker",
+            "nuPickers.XmlDropDownPicker",
+            "nuPickers.XmlLabels",
+            "nuPickers.XmlPagedListPicker",
+            "nuPickers.XmlPrefetchListPicker",
+            "nuPickers.XmlRadioButtonPicker",
+            "nuPickers.XmlTypeaheadListPicker"
+        };
+
+        /// <summary>
+        /// Gets the deploy property corresponding to a content property.
+        /// </summary>
+        /// <param name="property">The content property.</param>
+        /// <param name="dependencies">The content dependencies.</param>
+        /// <returns>The deploy property value.</returns>
+        public string GetValue(Property property, ICollection<ArtifactDependency> dependencies)
+        {
+            // get the property value
+            var value = property.Value as string;
+
+            // parse the value - checking the format - CSV, XML or JSON
+            var items = ParseValue(value, out SaveFormat format);
+
+            var result = new List<KeyValuePair<string, string>>();
+
+            // loop over the values
+            foreach (var item in items)
+            {
+                if (int.TryParse(item.Key, out int nodeId))
+                {
+                    // if an INT, attempt to get the UDI
+                    var guidUdi = GetGuidUdi(nodeId);
+                    if (guidUdi != null)
+                    {
+                        dependencies.Add(new ArtifactDependency(guidUdi, false, ArtifactDependencyMode.Exist));
+                        result.Add(new KeyValuePair<string, string>(guidUdi.ToString(), item.Value));
+                    }
+                    else
+                    {
+                        // the value isn't a UDI, assume it's "just a string"
+                        result.Add(item);
+                    }
+                }
+                else
+                {
+                    // the value isn't a node ID, assume it's "just a string"
+                    result.Add(item);
+                }
+            }
+
+            // return the value in the correct format - CSV, XML, JSON, (whatevs)
+            return SerializeValue(result, format);
+        }
+
+        /// <summary>
+        /// Sets a content property value using a deploy property.
+        /// </summary>
+        /// <param name="content">The content item.</param>
+        /// <param name="alias">The property alias.</param>
+        /// <param name="value">The deploy property value.</param>
+        public void SetValue(IContentBase content, string alias, string value)
+        {
+            // parse the value - checking the format - CSV, XML or JSON
+            var items = ParseValue(value, out SaveFormat format);
+
+            var result = new List<KeyValuePair<string, string>>();
+
+            // loop over the values
+            foreach (var item in items)
+            {
+                if (GuidUdi.TryParse(item.Key, out GuidUdi guidUdi) && guidUdi.Guid != Guid.Empty)
+                {
+                    // if an UDI, attempt to get the INT
+                    var nodeId = GetIntId(guidUdi.Guid);
+                    if (nodeId > 0)
+                    {
+                        result.Add(new KeyValuePair<string, string>(nodeId.ToString(), item.Value));
+                    }
+                    else
+                    {
+                        // the value isn't a node ID, assume it's "just a string"
+                        result.Add(item);
+                    }
+                }
+                else
+                {
+                    // the value isn't a UDI, assume it's "just a string"
+                    result.Add(item);
+                }
+            }
+
+            // re-assemble the values into the correct format - CSV, XML, JSON, (whatevs)
+            content.SetValue(alias, SerializeValue(result, format));
+        }
+
+        private IEnumerable<KeyValuePair<string, string>> ParseValue(string value, out SaveFormat format)
+        {
+            // code taken from nuPickers
+            // ref: https://github.com/uComponents/nuPickers/blob/master/source/nuPickers/Shared/SaveFormat/SaveFormat.cs#L43
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                switch (value[0])
+                {
+                    case '[':
+                        format = SaveFormat.JSON;
+                        return JsonConvert.DeserializeObject<JArray>(value).Select(x => new KeyValuePair<string, string>(x["key"].ToString(), x["label"].ToString()));
+
+                    case '<':
+                        format = SaveFormat.XML;
+                        return XDocument.Parse(value).Descendants("Picked").Select(x => new KeyValuePair<string, string>(x.Attribute("Key").Value, x.Value));
+
+                    default:
+                        format = SaveFormat.CSV;
+                        return value.Split(',').Select(x => new KeyValuePair<string, string>(x, null)); // NOTE: label is null
+                }
+            }
+
+            format = SaveFormat.CSV;
+            return Enumerable.Empty<KeyValuePair<string, string>>();
+        }
+
+        private string SerializeValue(IEnumerable<KeyValuePair<string, string>> value, SaveFormat format)
+        {
+            // ref: https://github.com/uComponents/nuPickers/wiki/Save-Formats
+            // ref: https://github.com/uComponents/nuPickers/blob/master/source/nuPickers/Shared/SaveFormat/SaveFormatResource.js#L16
+
+            switch (format)
+            {
+                case SaveFormat.JSON:
+                    var json = value.Select(x => $"{{ 'key': '{x.Key}', 'label': '{x.Value}' }}");
+                    return string.Concat("[", string.Join(",", json, "]"));
+
+                case SaveFormat.XML:
+                    var xml = value.Select(x => $"<Picked Key=\"{x.Key}\"><![CDATA[{x.Value}]]></Picked>");
+                    return string.Concat("<Picker>", string.Join(",", xml, "</Picker>"));
+
+                case SaveFormat.CSV:
+                default:
+                    return string.Join(",", value.Select(x => x.Key));
+            }
+        }
+
+        private GuidUdi GetGuidUdi(int id)
+        {
+            var keyForId = _entityService.GetKeyForId(id, UmbracoObjectTypes.Document);
+            if (keyForId.Success)
+                return new GuidUdi(Constants.UdiEntityType.Document, keyForId.Result);
+
+            keyForId = this._entityService.GetKeyForId(id, UmbracoObjectTypes.Media);
+            if (keyForId.Success)
+                return new GuidUdi(Constants.UdiEntityType.Media, keyForId.Result);
+
+            return null;
+        }
+
+        private int GetIntId(Guid id)
+        {
+            var idForKey = _entityService.GetIdForKey(id, UmbracoObjectTypes.Document);
+            if (idForKey.Success)
+                return idForKey.Result;
+
+            idForKey = _entityService.GetIdForKey(id, UmbracoObjectTypes.Media);
+            if (idForKey.Success)
+                return idForKey.Result;
+
+            return -1;
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -22,7 +22,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         {
             CSV,
             JSON,
-            XML,
+            XML
         }
 
         /// <summary>
@@ -48,14 +48,16 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             var value = property.Value as string;
 
             // parse the value - checking the format - CSV, XML or JSON
-            var items = ParseValue(value, out SaveFormat format);
+            SaveFormat format;
+            var items = ParseValue(value, out format);
 
             var result = new List<KeyValuePair<string, string>>();
 
             // loop over the values
             foreach (var item in items)
             {
-                if (int.TryParse(item.Key, out int nodeId))
+                int nodeId;
+                if (int.TryParse(item.Key, out nodeId))
                 {
                     // if an INT, attempt to get the UDI
                     var guidUdi = GetGuidUdi(nodeId);
@@ -90,14 +92,16 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         public void SetValue(IContentBase content, string alias, string value)
         {
             // parse the value - checking the format - CSV, XML or JSON
-            var items = ParseValue(value, out SaveFormat format);
+            SaveFormat format;
+            var items = ParseValue(value, out format);
 
             var result = new List<KeyValuePair<string, string>>();
 
             // loop over the values
             foreach (var item in items)
             {
-                if (GuidUdi.TryParse(item.Key, out GuidUdi guidUdi) && guidUdi.Guid != Guid.Empty)
+                GuidUdi guidUdi;
+                if (GuidUdi.TryParse(item.Key, out guidUdi) && guidUdi.Guid != Guid.Empty)
                 {
                     // if an UDI, attempt to get the INT
                     var nodeId = GetIntId(guidUdi.Guid);
@@ -175,7 +179,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             if (keyForId.Success)
                 return new GuidUdi(Constants.UdiEntityType.Document, keyForId.Result);
 
-            keyForId = this._entityService.GetKeyForId(id, UmbracoObjectTypes.Media);
+            keyForId = _entityService.GetKeyForId(id, UmbracoObjectTypes.Media);
             if (keyForId.Success)
                 return new GuidUdi(Constants.UdiEntityType.Media, keyForId.Result);
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -34,50 +34,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
         }
 
-        public IEnumerable<string> PropertyEditorAliases => new[]
-        {
-            "nuPickers.DotNetCheckBoxPicker",
-            "nuPickers.DotNetDropDownPicker",
-            "nuPickers.DotNetLabels",
-            "nuPickers.DotNetPagedListPicker",
-            "nuPickers.DotNetPrefetchListPicker",
-            "nuPickers.DotNetRadioButtonPicker",
-            "nuPickers.DotNetTypeaheadListPicker",
-            "nuPickers.EnumCheckBoxPicker",
-            "nuPickers.EnumDropDownPicker",
-            "nuPickers.EnumLabels",
-            "nuPickers.EnumPrefetchListPicker",
-            "nuPickers.EnumRadioButtonPicker",
-            "nuPickers.JsonCheckBoxPicker",
-            "nuPickers.JsonDropDownPicker",
-            "nuPickers.JsonLabels",
-            "nuPickers.JsonPagedListPicker",
-            "nuPickers.JsonPrefetchListPicker",
-            "nuPickers.JsonRadioButtonPicker",
-            "nuPickers.JsonTypeaheadListPicker",
-            "nuPickers.LuceneCheckBoxPicker",
-            "nuPickers.LuceneDropDownPicker",
-            "nuPickers.LuceneLabels",
-            "nuPickers.LucenePagedListPicker",
-            "nuPickers.LucenePrefetchListPicker",
-            "nuPickers.LuceneRadioButtonPicker",
-            "nuPickers.LuceneTypeaheadListPicker",
-            "nuPickers.RelationLabels",
-            "nuPickers.SqlCheckBoxPicker",
-            "nuPickers.SqlDropDownPicker",
-            "nuPickers.SqlLabels",
-            "nuPickers.SqlPagedListPicker",
-            "nuPickers.SqlPrefetchListPicker",
-            "nuPickers.SqlRadioButtonPicker",
-            "nuPickers.SqlTypeaheadListPicker",
-            "nuPickers.XmlCheckBoxPicker",
-            "nuPickers.XmlDropDownPicker",
-            "nuPickers.XmlLabels",
-            "nuPickers.XmlPagedListPicker",
-            "nuPickers.XmlPrefetchListPicker",
-            "nuPickers.XmlRadioButtonPicker",
-            "nuPickers.XmlTypeaheadListPicker"
-        };
+        public IEnumerable<string> PropertyEditorAliases => Enumerable.Empty<string>();
 
         /// <summary>
         /// Gets the deploy property corresponding to a content property.

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -12,7 +12,7 @@ using Umbraco.Core.Services;
 namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 {
     /// <summary>
-    /// A Deploy connector for the nuPickers property editor
+    /// A Deploy connector for the nuPickers property editor, when used with Umbraco content & media.
     /// </summary>
     public class NuPickersValueConnector : IValueConnector
     {


### PR DESCRIPTION
Adds a value-connector for nuPickers.

The reason being is that nuPickers is flexible with the data it can handle, it is not limited to content or media nodes.

When associating nuPickers with the `GenericNodeIdPickerValueConnector` (in "Deploy.Settings.config"), this would strip out any non-node ID values.  Meaning that if nuPickers is being used to store "just string" values, those wouldn't be transferred to the target environment.

This custom value-connector will keep any non-node ID values intact, so they are transferred.

