### PR TITLE
InnerContentConnector - adds `TryParse` for the JToken conversion

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/InnerContentConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/InnerContentConnector.cs
@@ -100,8 +100,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
                     // test if the value is a json object (thus could be a nested complex editor)
                     // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                    var jtokenValue = parsedValue != null && parsedValue.ToString().DetectIsJson() ? JToken.Parse(parsedValue.ToString()) : null;
-                    if (jtokenValue != null)
+                    JToken jtokenValue;
+                    if (TryParseJToken(parsedValue, out jtokenValue))
                     {
                         parsedValue = jtokenValue;
                     }
@@ -199,8 +199,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                         {
                             // test if the value is a json object (thus could be a nested complex editor)
                             // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                            var jtokenValue = convertedValue.ToString().DetectIsJson() ? JToken.Parse(convertedValue.ToString()) : null;
-                            if (jtokenValue != null)
+                            JToken jtokenValue;
+                            if (TryParseJToken(convertedValue, out jtokenValue))
                             {
                                 innerContentItem.PropertyValues[key] = jtokenValue;
                             }
@@ -220,6 +220,26 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             // InnerContent does not use formatting when serializing JSON values
             value = JArray.FromObject(innerContent).ToString(Formatting.None);
             content.SetValue(alias, value);
+        }
+
+        private static bool TryParseJToken(object value, out JToken json)
+        {
+            json = default(JToken);
+
+            if (value == null)
+                return false;
+
+            var s = value.ToString();
+            if (string.IsNullOrWhiteSpace(s) || s.DetectIsJson() == false)
+                return false;
+
+            try
+            {
+                json = JToken.Parse(s);
+            }
+            catch { }
+
+            return json != null;
         }
 
         /// <summary>


### PR DESCRIPTION
If a value is detected as JSON, but isn't actually valid JSON, e.g. a string such as "[hello world]", then the `JToken.Parse` will throw an exception.

This patch introduces a `TryParse` style method to indicate whether the JToken conversion was successful, otherwise the value-connector can use the original (unmodified) value.

---

I took a cue from the [`ConvertToJsonIfPossible` extension method](https://github.com/umbraco/Umbraco-CMS/blob/dev-v7/src/Umbraco.Core/StringExtensions.cs#L158) in Umbraco core.
