### PR TITLE
Add value-connector for Content List

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project offers Umbraco Deploy connectors for the following community packag
 - [Stacked Content](https://github.com/umco/umbraco-stacked-content)
 - [nuPickers](https://our.umbraco.org/projects/backoffice-extensions/nupickers/)
 - [Archetype](https://our.umbraco.org/projects/backoffice-extensions/archetype/)
+- [Content List](https://github.com/umco/umbraco-content-list)
 
 ---
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -242,6 +242,7 @@
     <Compile Include="ValueConnectors\NuPickersValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinksValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinks2ValueConnector.cs" />
+    <Compile Include="ValueConnectors\ContentListConnector.cs" />
     <Compile Include="ValueConnectors\VortoValueConnector.cs" />
     <Compile Include="ValueConnectors\InnerContentConnector.cs" />
     <Compile Include="ValueConnectors\StackedContentConnector.cs" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ContentListConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ContentListConnector.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Services;
+using Umbraco.Deploy.ValueConnectors;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    /// <summary>
+    /// A Deploy ValueConnector for the Content List property editor.
+    /// https://github.com/umco/umbraco-content-list
+    /// </summary>
+    public class ContentListConnector : InnerContentConnector
+    {
+        public override IEnumerable<string> PropertyEditorAliases => new[] { "Our.Umbraco.ContentList" };
+
+        public ContentListConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors)
+            : base(contentTypeService, valueConnectors)
+        { }
+    }
+}


### PR DESCRIPTION
We are preparing a release of a new property-editor called "[Content List](https://github.com/umco/umbraco-content-list)", and wanted to have Umbraco Cloud support upfront.

This is another "Inner Content" property-editor, so it re-uses the existing value-connector logic.

