### PR TITLE
Add value-connector for Tuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project offers Umbraco Deploy connectors for the following community packag
 - [Stacked Content](https://github.com/umco/umbraco-stacked-content)
 - [nuPickers](https://our.umbraco.org/projects/backoffice-extensions/nupickers/)
 - [Archetype](https://our.umbraco.org/projects/backoffice-extensions/archetype/)
+- [Tuple](https://github.com/umco/umbraco-tuple)
 
 ---
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -242,6 +242,7 @@
     <Compile Include="ValueConnectors\NuPickersValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinksValueConnector.cs" />
     <Compile Include="ValueConnectors\RelatedLinks2ValueConnector.cs" />
+    <Compile Include="ValueConnectors\TupleValueConnector.cs" />
     <Compile Include="ValueConnectors\VortoValueConnector.cs" />
     <Compile Include="ValueConnectors\InnerContentConnector.cs" />
     <Compile Include="ValueConnectors\StackedContentConnector.cs" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/TupleValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/TupleValueConnector.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Deploy.ValueConnectors;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    public class TupleValueConnector : IValueConnector
+    {
+        private readonly IDataTypeService _dataTypeService;
+        private readonly Lazy<ValueConnectorCollection> _valueConnectorsLazy;
+
+        public TupleValueConnector(IDataTypeService dataTypeService, Lazy<ValueConnectorCollection> valueConnectors)
+        {
+            Mandate.ParameterNotNull(dataTypeService, nameof(dataTypeService));
+            Mandate.ParameterNotNull(valueConnectors, nameof(valueConnectors));
+
+            _dataTypeService = dataTypeService;
+            _valueConnectorsLazy = valueConnectors;
+        }
+
+        public IEnumerable<string> PropertyEditorAliases => new[] { "Our.Umbraco.Tuple" };
+
+        private ValueConnectorCollection ValueConnectors => _valueConnectorsLazy.Value;
+
+        public string GetValue(Property property, ICollection<ArtifactDependency> dependencies)
+        {
+            // get the property value
+            var value = property.Value?.ToString();
+            if (string.IsNullOrWhiteSpace(value))
+                return null;
+
+            // deserialize it
+            var items = JsonConvert.DeserializeObject<List<TupleValueItem>>(value);
+            if (items == null || items.Count == 0)
+                return null;
+
+            // loop through each value
+            foreach (var item in items)
+            {
+                // get the selected data-type (and ensure it exists)
+                var dataType = _dataTypeService.GetDataTypeDefinitionById(item.DataTypeGuid);
+
+                if (dataType == null)
+                {
+                    LogHelper.Warn<TupleValueConnector>($"Could not resolve the data-type used by the Property List value for: {property.Alias}, with GUID: {item.DataTypeGuid}");
+                    continue;
+                }
+
+                // add the selected data-type as a dependency
+                dependencies.Add(new ArtifactDependency(dataType.GetUdi(), false, ArtifactDependencyMode.Match));
+
+                // make a property-type to use in a mocked Property
+                // and get the value-connector needed to parse values (outside the loop, as it's the same for all iterations)
+                var propertyType = new PropertyType(dataType);
+                var valueConnector = ValueConnectors.Get(propertyType);
+
+                item.Value = valueConnector.GetValue(new Property(propertyType, item.Value), dependencies);
+            }
+
+            return JsonConvert.SerializeObject(items);
+        }
+
+        public void SetValue(IContentBase content, string alias, string value)
+        {
+            // take the value
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+
+            // deserialize it
+            var items = JsonConvert.DeserializeObject<List<TupleValueItem>>(value);
+            if (items == null || items.Count == 0)
+                return;
+
+            // loop through each value
+            foreach (var item in items)
+            {
+                // get the selected data-type (and ensure it exists)
+                var dataType = _dataTypeService.GetDataTypeDefinitionById(item.DataTypeGuid);
+
+                if (dataType == null)
+                {
+                    LogHelper.Warn<TupleValueConnector>($"Could not resolve the data-type used by the Tuple item for: {alias}, with GUID: {item.DataTypeGuid}");
+                    continue;
+                }
+
+                // make a property-type to use in a mocked Property
+                // and get the value-connector needed to parse values (outside the loop, as it's the same for all iterations)
+                var propertyType = new PropertyType(dataType, "mockTupleAlias");
+                var valueConnector = ValueConnectors.Get(propertyType);
+
+                var mockProperty = new Property(propertyType);
+                var mockContent = new Content("mockContent", -1, new ContentType(-1), new PropertyCollection(new List<Property> { mockProperty }));
+
+                // pass it to its own value-connector
+                // NOTE: due to how ValueConnector.SetValue() works, we have to pass the mock item
+                // through to the connector to have it do its work on parsing the value on the item itself.
+                valueConnector.SetValue(mockContent, mockProperty.Alias, item.Value?.ToString());
+
+                // get the value back and assign
+                item.Value = mockContent.GetValue(mockProperty.Alias);
+            }
+
+            // serialize the JSON values
+            content.SetValue(alias, JArray.FromObject(items).ToString(Formatting.None));
+        }
+
+        public class TupleValueItem
+        {
+            [JsonProperty("key")]
+            public Guid Key { get; set; }
+
+            [JsonProperty("dtd")]
+            public Guid DataTypeGuid { get; set; }
+
+            [JsonProperty("value")]
+            public object Value { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Tests/Connectors/TupleValueConnectorTests.cs
+++ b/src/Umbraco.Deploy.Contrib.Tests/Connectors/TupleValueConnectorTests.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Configuration;
+using Umbraco.Core.Configuration.UmbracoSettings;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Deploy.Contrib.Connectors.ValueConnectors;
+using Umbraco.Deploy.ValueConnectors;
+
+namespace Umbraco.Deploy.Contrib.Tests.Connectors
+{
+    [TestFixture]
+    public class TupleValueConnectorTests
+    {
+        [Test]
+        public void GetValueTest()
+        {
+            var dataTypeService = Mock.Of<IDataTypeService>();
+
+            var tupleDataType = new DataTypeDefinition("tupleEditorAlias")
+            {
+                Id = 1,
+                Key = Guid.Parse("3BBFB03B-B6AD-4310-986B-44E9F31A4F1F"),
+                DatabaseType = DataTypeDatabaseType.Ntext
+            };
+
+            var innerDataType = new DataTypeDefinition("innerEditorAlias")
+            {
+                Id = 2,
+                Key = Guid.Parse("0F6DCC71-2FA7-496B-A858-8D6DDAF37F59"),
+                DatabaseType = DataTypeDatabaseType.Integer // for true/false
+            };
+
+            var dataTypes = new[] { tupleDataType, innerDataType };
+
+            Mock.Get(dataTypeService)
+                .Setup(x => x.GetDataTypeDefinitionById(It.IsAny<Guid>()))
+                .Returns<Guid>(id => dataTypes.FirstOrDefault(x => x.Key == id));
+
+            var preValues = new Dictionary<int, PreValueCollection>
+            {
+                { 1, new PreValueCollection(new Dictionary<string, PreValue> { { "dataTypes", new PreValue( $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\"}}]") } }) }
+            };
+
+            Mock.Get(dataTypeService)
+                .Setup(x => x.GetPreValuesCollectionByDataTypeId(It.IsAny<int>()))
+                .Returns<int>(id => preValues.TryGetValue(id, out var collection) ? collection : null);
+
+            ValueConnectorCollection connectors = null;
+            var defaultConnector = new DefaultValueConnector();
+            var tupleConnector = new TupleValueConnector(dataTypeService, new Lazy<ValueConnectorCollection>(() => connectors));
+            connectors = new ValueConnectorCollection(new Dictionary<string, IValueConnector>
+            {
+                { "innerEditorAlias", defaultConnector },
+                { "tupleEditorAlias", tupleConnector }
+            });
+
+            var input = $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\",\"value\":0}}]";
+
+            var propertyType = new PropertyType(tupleDataType);
+            var property = new Property(propertyType, input);
+            var dependencies = new List<ArtifactDependency>();
+            var output = tupleConnector.GetValue(property, dependencies);
+
+            Console.WriteLine(output);
+
+            var expected = $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\",\"value\":\"i0\"}}]";
+            Assert.AreEqual(expected, output);
+        }
+
+        [Test]
+        public void SetValueTest()
+        {
+            var dataTypeService = Mock.Of<IDataTypeService>();
+
+            var tupleDataType = new DataTypeDefinition("tupleEditorAlias")
+            {
+                Id = 1,
+                Key = Guid.Parse("3BBFB03B-B6AD-4310-986B-44E9F31A4F1F"),
+                DatabaseType = DataTypeDatabaseType.Ntext
+            };
+
+            var innerDataType = new DataTypeDefinition("innerEditorAlias")
+            {
+                Id = 2,
+                Key = Guid.Parse("0F6DCC71-2FA7-496B-A858-8D6DDAF37F59"),
+                DatabaseType = DataTypeDatabaseType.Integer // for true/false
+            };
+
+            var dataTypes = new[] { tupleDataType, innerDataType };
+
+            Mock.Get(dataTypeService)
+                .Setup(x => x.GetDataTypeDefinitionById(It.IsAny<Guid>()))
+                .Returns<Guid>(id => dataTypes.FirstOrDefault(x => x.Key == id));
+
+            var preValues = new Dictionary<int, PreValueCollection>
+            {
+                { 1, new PreValueCollection(new Dictionary<string, PreValue> { { "dataTypes", new PreValue( $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\"}}]") } }) }
+            };
+
+            Mock.Get(dataTypeService)
+                .Setup(x => x.GetPreValuesCollectionByDataTypeId(It.IsAny<int>()))
+                .Returns<int>(id => preValues.TryGetValue(id, out var collection) ? collection : null);
+
+            ValueConnectorCollection connectors = null;
+            var defaultConnector = new DefaultValueConnector();
+            var tupleConnector = new TupleValueConnector(dataTypeService, new Lazy<ValueConnectorCollection>(() => connectors));
+            connectors = new ValueConnectorCollection(new Dictionary<string, IValueConnector>
+            {
+                { "innerEditorAlias", defaultConnector },
+                { "tupleEditorAlias", tupleConnector }
+            });
+
+            var input = $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\",\"value\":\"i0\"}}]";
+
+            UmbracoConfig.For.SetUmbracoSettings(GenerateMockSettings());
+
+            var tuplePropertyType = new PropertyType(tupleDataType, "tupleProperty");
+            var tupleProperty = new Property(tuplePropertyType, null); // value is going to be replaced
+            var tupleContent = new Content("mockContent", -1, new ContentType(-1), new PropertyCollection(new List<Property> { tupleProperty }));
+            tupleConnector.SetValue(tupleContent, "tupleProperty", input);
+
+            var output = tupleContent.GetValue("tupleProperty");
+
+            Assert.IsInstanceOf<string>(output);
+
+            Console.WriteLine(output);
+
+            var expected = $"[{{\"key\":\"{Guid.Empty}\",\"dtd\":\"{innerDataType.Key}\",\"value\":0}}]";
+            Assert.AreEqual(expected, output);
+        }
+
+        public static IUmbracoSettingsSection GenerateMockSettings()
+        {
+            var settings = new Mock<IUmbracoSettingsSection>();
+
+            var content = new Mock<IContentSection>();
+            var security = new Mock<ISecuritySection>();
+            var requestHandler = new Mock<IRequestHandlerSection>();
+            var templates = new Mock<ITemplatesSection>();
+            var dev = new Mock<IDeveloperSection>();
+            var logging = new Mock<ILoggingSection>();
+            var tasks = new Mock<IScheduledTasksSection>();
+            var distCall = new Mock<IDistributedCallSection>();
+            var repos = new Mock<IRepositoriesSection>();
+            var providers = new Mock<IProvidersSection>();
+            var routing = new Mock<IWebRoutingSection>();
+
+            settings.Setup(x => x.Content).Returns(content.Object);
+            settings.Setup(x => x.Security).Returns(security.Object);
+            settings.Setup(x => x.RequestHandler).Returns(requestHandler.Object);
+            settings.Setup(x => x.Templates).Returns(templates.Object);
+            settings.Setup(x => x.Developer).Returns(dev.Object);
+            settings.Setup(x => x.Logging).Returns(logging.Object);
+            settings.Setup(x => x.ScheduledTasks).Returns(tasks.Object);
+            settings.Setup(x => x.DistributedCall).Returns(distCall.Object);
+            settings.Setup(x => x.PackageRepositories).Returns(repos.Object);
+            settings.Setup(x => x.Providers).Returns(providers.Object);
+            settings.Setup(x => x.WebRouting).Returns(routing.Object);
+
+            //Now configure some defaults - the defaults in the config section classes do NOT pertain to the mocked data!!
+            settings.Setup(x => x.Content.ForceSafeAliases).Returns(true);
+            //settings.Setup(x => x.Content.ImageAutoFillProperties).Returns(ContentImagingElement.GetDefaultImageAutoFillProperties());
+            //settings.Setup(x => x.Content.ImageFileTypes).Returns(ContentImagingElement.GetDefaultImageFileTypes());
+            settings.Setup(x => x.RequestHandler.AddTrailingSlash).Returns(true);
+            settings.Setup(x => x.RequestHandler.UseDomainPrefixes).Returns(false);
+            //settings.Setup(x => x.RequestHandler.CharCollection).Returns(RequestHandlerElement.GetDefaultCharReplacements());
+            settings.Setup(x => x.Content.UmbracoLibraryCacheDuration).Returns(1800);
+            settings.Setup(x => x.WebRouting.UrlProviderMode).Returns("AutoLegacy");
+            settings.Setup(x => x.Templates.DefaultRenderingEngine).Returns(RenderingEngine.Mvc);
+            settings.Setup(x => x.Providers.DefaultBackOfficeUserProvider).Returns("UsersMembershipProvider");
+
+            return settings.Object;
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Tests/Umbraco.Deploy.Contrib.Tests.csproj
+++ b/src/Umbraco.Deploy.Contrib.Tests/Umbraco.Deploy.Contrib.Tests.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Connectors\LeBlenderGridCellValueConnectorTests.cs" />
     <Compile Include="Connectors\NestedContentValueConnectorTests.cs" />
     <Compile Include="Connectors\UrlPickerValueConnectorTests.cs" />
+    <Compile Include="Connectors\TupleValueConnectorTests.cs" />
     <Compile Include="Connectors\VortoValueConnectorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestHelpers\MemoryFileTypeCollection.cs" />


### PR DESCRIPTION
We are preparing a release of a new property-editor called "[Tuple](https://github.com/umco/umbraco-tuple)", and wanted to have Umbraco Cloud support upfront.

I've included a unit-test too, (following the example from the Vorto unit-test).