### PR TITLE
Cogworks.Meganav connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ bower_components/
 node_modules/
 Umbraco.Deploy.UI.Client/build/
 build/Tools/nuget.exe
+
+src/Umbraco.Deploy.Contrib.Connectors/App_Plugins/*
+src/Umbraco.Deploy.Contrib.Connectors/Config/*
+src/Umbraco.Deploy.Contrib.Connectors/app.config

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This project offers Umbraco Deploy connectors for the following community packag
 - [Content List](https://github.com/umco/umbraco-content-list)
 - [DocType Grid Editor](https://our.umbraco.org/projects/backoffice-extensions/doc-type-grid-editor/)
 - [LeBlender](https://our.umbraco.org/projects/backoffice-extensions/leblender)
+- [Meganav](https://our.umbraco.com/projects/website-utilities/meganav/)
 - [Multi Url Picker](https://our.umbraco.com/projects/backoffice-extensions/multi-url-picker)
 - [Nested Content](https://our.umbraco.org/projects/backoffice-extensions/nested-content/)
 - [nuPickers](https://our.umbraco.org/projects/backoffice-extensions/nupickers/)

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="ValueConnectors\ArchetypeValueConnector.cs" />
+    <Compile Include="ValueConnectors\MeganavValueConnector.cs" />
     <Compile Include="ValueConnectors\MultiUrlPickerValueConnector.cs" />
     <Compile Include="ValueConnectors\NuPickersValueConnector.cs" />
     <Compile Include="ValueConnectors\PropertyListValueConnector.cs" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
@@ -413,7 +413,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             [JsonProperty("disabled")]
             public bool Disabled { get; set; }
 
-            [JsonProperty("properties")] public IEnumerable<ArchetypePropertyModel> Properties;
+            [JsonProperty("properties")]
+            public IEnumerable<ArchetypePropertyModel> Properties { get; set; }
 
             [JsonProperty("id")]
             public Guid Id { get; set; }
@@ -457,7 +458,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         {
             // container for the names of any files selected for a property in the Umbraco backend
             [JsonProperty("fileNames")]
-            public IEnumerable<string> FileNames;
+            public IEnumerable<string> FileNames { get; set; }
         }
     }
 }

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MeganavValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MeganavValueConnector.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    public class MeganavValueConnector : IValueConnector
+    {
+        /// <summary>
+        /// The entity service.
+        /// </summary>
+        private readonly IEntityService entityService;
+
+        /// <summary>
+        /// Gets the property editor aliases that the value converter supports by default.
+        /// </summary>
+        public IEnumerable<string> PropertyEditorAliases => new string[] { "Cogworks.Meganav" };
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MeganavValueConnector"/> class.
+        /// </summary>
+        /// <param name="entityService">The entity service.</param>
+        /// <exception cref="ArgumentNullException">entityService</exception>
+        public MeganavValueConnector(IEntityService entityService)
+        {
+            this.entityService = entityService ?? throw new ArgumentNullException("entityService");
+        }
+
+        /// <summary>
+        /// Gets the deploy property corresponding to a content property.
+        /// </summary>
+        /// <param name="property">The content property.</param>
+        /// <param name="dependencies">The content dependencies.</param>
+        /// <returns>
+        /// The deploy property value.
+        /// </returns>
+        public string GetValue(Property property, ICollection<ArtifactDependency> dependencies)
+        {
+            var value = property.Value as string;
+            if (String.IsNullOrWhiteSpace(value) || !StringExtensions.DetectIsJson(value))
+            {
+                return null;
+            }
+
+            // Parse links and convert ID to UDI
+            var links = JArray.Parse(value);
+            foreach (var link in links)
+            {
+                GuidUdi guidUdi = null;
+                int id = link.Value<int>("id");
+                if (id != 0)
+                {
+                    Attempt<Guid> keyForId = this.entityService.GetKeyForId(id, UmbracoObjectTypes.Document);
+                    if (keyForId.Success)
+                    {
+                        guidUdi = new GuidUdi("document", keyForId.Result);
+                        dependencies.Add(new ArtifactDependency(guidUdi, false, ArtifactDependencyMode.Exist));
+                    }
+                }
+
+                link["id"] = guidUdi?.ToString();
+            }
+
+            return links.ToString(Formatting.None);
+        }
+
+        /// <summary>
+        /// Sets a content property value using a deploy property.
+        /// </summary>
+        /// <param name="content">The content item.</param>
+        /// <param name="alias">The property alias.</param>
+        /// <param name="value">The deploy property value.</param>
+        public void SetValue(IContentBase content, string alias, string value)
+        {
+            if (String.IsNullOrWhiteSpace(value))
+            {
+                // Save empty value
+                content.SetValue(alias, value);
+                return;
+            }
+
+            if (!StringExtensions.DetectIsJson(value))
+            {
+                // Skip invalid value (probably shoudn't be saved, right?)
+                return;
+            }
+
+            // Parse links and convert UDI back to local ID
+            var links = JArray.Parse(value);
+            foreach (var link in links)
+            {
+                int id = 0;
+                if (GuidUdi.TryParse(link.Value<string>("id"), out GuidUdi guidUdi))
+                {
+                    Attempt<int> idForUdi = this.entityService.GetIdForUdi(guidUdi);
+                    if (idForUdi.Success)
+                    {
+                        id = idForUdi.Result;
+                    }
+                }
+
+                link["id"] = id;
+            }
+
+            content.SetValue(alias, links.ToString(Formatting.None));
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/RelatedLinks2ValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/RelatedLinks2ValueConnector.cs
@@ -56,7 +56,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             {
                 relatedLinks = JsonConvert.DeserializeObject<List<RelatedLinkUdiModel>>(value);
             }
-            catch (JsonSerializationException ex)
+            catch (JsonSerializationException)
             {
                 // We might be transferring related links stored as int id, parse with ints instead.
 


### PR DESCRIPTION
Although Cogworks has 'Umbraco Cloud / Courier' support listed as coming soon, I'm using this great property editor _right now_ on websites running on UC: https://github.com/thecogworks/meganav.  So I decided to write the connector myself and add it to this project (to keep additional assemblies to a minimum)... The connector itself is simple: replace id's with UDIs (and reverse on deploy) and track the dependencies.

I also ignored the Umbraco Deploy content files that are restored from NuGet and fixed 3 warnings (unused `ex` variable and 2 fields that should be properties).