### PR TITLE
Improves the performance of publishing pages that contain Archetype p…

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/Caching/Comparers/StringArrayComparer.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Caching/Comparers/StringArrayComparer.cs
@@ -1,0 +1,82 @@
+﻿namespace Umbraco.Deploy.Contrib.Connectors.Caching.Comparers
+{
+
+    // Namespaces.
+    using System.Collections.Generic;
+    using System.Linq;
+
+    /// <summary>
+    /// Compares an array of strings.
+    /// </summary>
+    /// <remarks>
+    /// Based on: https://github.com/rhythmagency/rhythm.caching.core/blob/master/src/Rhythm.Caching.Core/Comparers/StringArrayComparer.cs
+    /// </remarks>
+    public class StringArrayComparer : IEqualityComparer<string[]>
+    {
+
+        #region Methods
+
+        /// <summary>
+        /// Check if the arrays are equal.
+        /// </summary>
+        /// <param name="x">
+        /// The first array.
+        /// </param>
+        /// <param name="y">
+        /// The second array.
+        /// </param>
+        /// <returns>
+        /// True, if the arrays are both null, are both empty, or both have
+        /// the same strings in the same order; otherwise, false.
+        /// </returns>
+        public bool Equals(string[] x, string[] y)
+        {
+            if (x == null || y == null)
+            {
+                return x == null && y == null;
+            }
+            if (x.Length != y.Length)
+            {
+                return false;
+            }
+            for (var i = 0; i < x.Length; i++)
+            {
+                if (x[i] != y[i])
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Generates a hash code by combining all of the hash codes for the strings in the array.
+        /// </summary>
+        /// <param name="items">
+        /// The array of strings.
+        /// </param>
+        /// <returns>
+        /// The combined hash code.
+        /// </returns>
+        public int GetHashCode(string[] items)
+        {
+            if (items == null || !items.Any())
+            {
+                return 0;
+            }
+            else
+            {
+                var hashCode = default(int);
+                foreach (var item in items)
+                {
+                    hashCode ^= (item ?? string.Empty).GetHashCode();
+                }
+                return hashCode;
+            }
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/Caching/Comparers/StringArrayComparer.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Caching/Comparers/StringArrayComparer.cs
@@ -1,9 +1,8 @@
-﻿namespace Umbraco.Deploy.Contrib.Connectors.Caching.Comparers
-{
+﻿using System.Collections.Generic;
+using System.Linq;
 
-    // Namespaces.
-    using System.Collections.Generic;
-    using System.Linq;
+namespace Umbraco.Deploy.Contrib.Connectors.Caching.Comparers
+{
 
     /// <summary>
     /// Compares an array of strings.
@@ -13,8 +12,6 @@
     /// </remarks>
     public class StringArrayComparer : IEqualityComparer<string[]>
     {
-
-        #region Methods
 
         /// <summary>
         /// Check if the arrays are equal.
@@ -74,8 +71,6 @@
                 return hashCode;
             }
         }
-
-        #endregion
 
     }
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Caching/InstanceByKeyCache.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Caching/InstanceByKeyCache.cs
@@ -1,10 +1,9 @@
-﻿namespace Umbraco.Deploy.Contrib.Connectors.Caching
-{
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Deploy.Contrib.Connectors.Caching.Comparers;
 
-    // Namespaces.
-    using Comparers;
-    using System;
-    using System.Collections.Generic;
+namespace Umbraco.Deploy.Contrib.Connectors.Caching
+{
 
     /// <summary>
     /// Caches instance variables by key in a dictionary-like structure.
@@ -21,13 +20,10 @@
     public class InstanceByKeyCache<T, TKey>
     {
 
-        #region Static Variables
-
+        /// <summary>
+        /// An empty array (convenience variable).
+        /// </summary>
         private static string[] EmptyArray = new string[] { };
-
-        #endregion
-
-        #region Properties
 
         /// <summary>
         /// The instances stored by their key, then again by a contextual key.
@@ -39,10 +35,6 @@
         /// </summary>
         private object InstancesLock { get; set; }
 
-        #endregion
-
-        #region Constructors
-
         /// <summary>
         /// Default constructor.
         /// </summary>
@@ -51,10 +43,6 @@
             InstancesLock = new object();
             Instances = new Dictionary<TKey, Tuple<Dictionary<string[], T>, DateTime>>();
         }
-
-        #endregion
-
-        #region Methods
 
         /// <summary>
         /// Gets the instance variable (either from the cache or from the specified function).
@@ -150,10 +138,6 @@
                 }
             }
         }
-
-        #endregion
-
-        #region Private Methods
 
         /// <summary>
         /// Trys to get the value by the specified keys.
@@ -257,8 +241,6 @@
                 instanceDictionary, lastCache);
 
         }
-
-        #endregion
 
     }
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Caching/InstanceByKeyCache.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Caching/InstanceByKeyCache.cs
@@ -1,0 +1,265 @@
+﻿namespace Umbraco.Deploy.Contrib.Connectors.Caching
+{
+
+    // Namespaces.
+    using Comparers;
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// Caches instance variables by key in a dictionary-like structure.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of value to cache.
+    /// </typeparam>
+    /// <typeparam name="TKey">
+    /// The key to use when access values in the dictionary.
+    /// </typeparam>
+    /// <remarks>
+    /// Adapted from: https://github.com/rhythmagency/rhythm.caching.core/blob/master/src/Rhythm.Caching.Core/Caches/InstanceByKeyCache.cs
+    /// </remarks>
+    public class InstanceByKeyCache<T, TKey>
+    {
+
+        #region Static Variables
+
+        private static string[] EmptyArray = new string[] { };
+
+        #endregion
+
+        #region Properties
+
+        /// <summary>
+        /// The instances stored by their key, then again by a contextual key.
+        /// </summary>
+        private Dictionary<TKey, Tuple<Dictionary<string[], T>, DateTime>> Instances { get; set; }
+
+        /// <summary>
+        /// Object to perform locks for cross-thread safety.
+        /// </summary>
+        private object InstancesLock { get; set; }
+
+        #endregion
+
+        #region Constructors
+
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
+        public InstanceByKeyCache()
+        {
+            InstancesLock = new object();
+            Instances = new Dictionary<TKey, Tuple<Dictionary<string[], T>, DateTime>>();
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Gets the instance variable (either from the cache or from the specified function).
+        /// </summary>
+        /// <param name="key">
+        /// The key to use when fetching the variable.
+        /// </param>
+        /// <param name="replenisher">
+        /// The function that replenishes the cache.
+        /// </param>
+        /// <param name="duration">
+        /// The duration to cache for.
+        /// </param>
+        /// <param name="method">
+        /// Optional. The cache method to use when retrieving the value.
+        /// </param>
+        /// <param name="keys">
+        /// Optional. The keys to store/retrieve a value by. Each key combination will
+        /// be treated as a separate cache.
+        /// </param>
+        /// <returns>
+        /// The value.
+        /// </returns>
+        public T Get(TKey key, Func<TKey, T> replenisher, TimeSpan duration, params string[] keys)
+        {
+            lock (InstancesLock)
+            {
+
+                // Variables.
+                var tempInstance = default(T);
+                var now = DateTime.Now;
+
+                // Value already cached?
+                var tempTuple = default(Tuple<Dictionary<string[], T>, DateTime>);
+                if (Instances.TryGetValue(key, out tempTuple)
+                    && tempTuple.Item1.ContainsKey(keys))
+                {
+                    if (now.Subtract(Instances[key].Item2) >= duration)
+                    {
+
+                        // Cache expired. Replenish the cache.
+                        tempInstance = replenisher(key);
+                        UpdateValueByKeys(keys, key, tempInstance, now, false);
+
+                    }
+                    else
+                    {
+
+                        // Cache still valid. Use cached value.
+                        tempInstance = TryGetByKeys(keys, key);
+
+                    }
+                }
+                else
+                {
+
+                    // No cached value. Replenish the cache.
+                    tempInstance = replenisher(key);
+                    UpdateValueByKeys(keys, key, tempInstance, now, false);
+
+                }
+
+                // Return the instance.
+                return tempInstance;
+
+            }
+        }
+
+        /// <summary>
+        /// Clears the cache.
+        /// </summary>
+        public void Clear()
+        {
+            lock (InstancesLock)
+            {
+                Instances.Clear();
+            }
+        }
+
+        /// <summary>
+        /// Clears the cache of the specified keys.
+        /// </summary>
+        /// <param name="keys">
+        /// The keys to clear the cache of.
+        /// </param>
+        public void ClearKeys(IEnumerable<TKey> keys)
+        {
+            lock (InstancesLock)
+            {
+                foreach (var key in keys)
+                {
+                    Instances.Remove(key);
+                }
+            }
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        /// <summary>
+        /// Trys to get the value by the specified keys.
+        /// </summary>
+        /// <param name="keys">
+        /// The keys.
+        /// </param>
+        /// <param name="accessKey">
+        /// The key to use to access the value.
+        /// </param>
+        /// <returns>
+        /// The value, or the default for the type.
+        /// </returns>
+        private T TryGetByKeys(string[] keys, TKey accessKey)
+        {
+            var chosenKeys = keys ?? EmptyArray;
+            var value = default(T);
+            lock (InstancesLock)
+            {
+                var valueDictionary = default(Tuple<Dictionary<string[], T>, DateTime>);
+                if (Instances.TryGetValue(accessKey, out valueDictionary))
+                {
+                    if (valueDictionary.Item1.TryGetValue(chosenKeys, out value))
+                    {
+                        return value;
+                    }
+                }
+            }
+            return default(T);
+        }
+
+        /// <summary>
+        /// Updates the cache value by the specified keys.
+        /// </summary>
+        /// <param name="keys">
+        /// The keys to cache by.
+        /// </param>
+        /// <param name="accessKey">
+        /// The key to use to access the value.
+        /// </param>
+        /// <param name="value">
+        /// The value to update the cache with.
+        /// </param>
+        /// <param name="lastCache">
+        /// The date/time to mark the cache as last updated.
+        /// </param>
+        /// <param name="doLock">
+        /// Lock the instance cache during the update?
+        /// </param>
+        private void UpdateValueByKeys(string[] keys, TKey accessKey, T value,
+            DateTime lastCache, bool doLock = true)
+        {
+            if (doLock)
+            {
+                lock (InstancesLock)
+                {
+                    UpdateValueByKeysWithoutLock(keys, accessKey, value, lastCache);
+                }
+            }
+            else
+            {
+                UpdateValueByKeysWithoutLock(keys, accessKey, value, lastCache);
+            }
+        }
+
+        /// <summary>
+        /// Updates the cache with the specified value.
+        /// </summary>
+        /// <param name="keys">
+        /// The keys to cache by.
+        /// </param>
+        /// <param name="accessKey">
+        /// The key to use to access the value.
+        /// </param>
+        /// <param name="value">
+        /// The value to update the cache with.
+        /// </param>
+        private void UpdateValueByKeysWithoutLock(string[] keys, TKey accessKey,
+            T value, DateTime lastCache)
+        {
+
+            // Variables.
+            var instanceTuple = default(Tuple<Dictionary<string[], T>, DateTime>);
+            var instanceDictionary = default(Dictionary<string[], T>);
+
+            // Get or create the dictionary.
+            if (Instances.TryGetValue(accessKey, out instanceTuple))
+            {
+                instanceDictionary = instanceTuple.Item1;
+            }
+            else
+            {
+                instanceDictionary = new Dictionary<string[], T>(new StringArrayComparer());
+            }
+
+            // Update the value in the dictionary.
+            instanceDictionary[keys] = value;
+
+            // Update the last cache date.
+            Instances[accessKey] = new Tuple<Dictionary<string[], T>, DateTime>(
+                instanceDictionary, lastCache);
+
+        }
+
+        #endregion
+
+    }
+
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -66,6 +66,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Caching\Comparers\StringArrayComparer.cs" />
+    <Compile Include="Caching\InstanceByKeyCache.cs" />
     <Compile Include="GridCellValueConnectors\DocTypeGridEditorCellValueConnector.cs" />
     <Compile Include="GridCellValueConnectors\LeBlenderGridCellValueConnector.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
@@ -1,19 +1,36 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Umbraco.Core;
 using Umbraco.Core.Deploy;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Core.Services;
+using Umbraco.Deploy.Contrib.Connectors.Caching;
 using Umbraco.Deploy.ValueConnectors;
 
 namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 {
     public class ArchetypeValueConnector : IValueConnector
     {
+
+        /// <summary>
+        /// The duration that results for operations related to data types are cached.
+        /// </summary>
+        private readonly TimeSpan dataTypeCacheDuration;
+
+        /// <summary>
+        /// Stores the string version of the Archetype config prevalues using the data type definition ID as the key.
+        /// </summary>
+        private readonly InstanceByKeyCache<string, int> archetypeConfigPreValuesByDtdId;
+
+        /// <summary>
+        /// Stores data type definitions using the data type definition GUID ID as the key.
+        /// </summary>
+        private readonly InstanceByKeyCache<DataTypeDefinition, Guid> dataTypeDefinitionsById;
+
         private readonly IDataTypeService _dataTypeService;
         private readonly IMacroParser _macroParser;
         private readonly Lazy<ValueConnectorCollection> _valueConnectorsLazy;
@@ -24,6 +41,9 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
         public ArchetypeValueConnector(IDataTypeService dataTypeService, IMacroParser macroParser, Lazy<ValueConnectorCollection> valueConnectors)
         {
+            dataTypeCacheDuration = TimeSpan.FromSeconds(30);
+            archetypeConfigPreValuesByDtdId = new InstanceByKeyCache<string, int>();
+            dataTypeDefinitionsById = new InstanceByKeyCache<DataTypeDefinition, Guid>();
             _dataTypeService = dataTypeService;
             _macroParser = macroParser;
             _valueConnectorsLazy = valueConnectors;
@@ -35,17 +55,10 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                 return null;
 
             var value = property.Value.ToString();
-
-            var prevalues = _dataTypeService.GetPreValuesCollectionByDataTypeId(property.PropertyType.DataTypeDefinitionId).PreValuesAsDictionary;
-            PreValue prevalue;
-            //Fetch the Prevalues for the current Property's DataType (if its an 'Archetype config')
-            if (!prevalues.TryGetValue("archetypeconfig", out prevalue) && !prevalues.TryGetValue("archetypeConfig", out prevalue))
-            {
-                throw new InvalidOperationException("Could not find Archetype configuration.");
-            }
-            var archetypePreValue = prevalue == null
+            var strPrevalue = GetArchetypeConfiguration(property.PropertyType.DataTypeDefinitionId);
+            var archetypePreValue = strPrevalue == null
                 ? null
-                : JsonConvert.DeserializeObject<ArchetypePreValue>(prevalue.Value);
+                : JsonConvert.DeserializeObject<ArchetypePreValue>(strPrevalue);
 
             RetrieveAdditionalProperties(ref archetypePreValue);
 
@@ -62,13 +75,11 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             {
                 if (archetypeProperty.DataTypeGuid == null)
                     continue;
+
                 // get the data type of the property
-                var dataType = _dataTypeService.GetDataTypeDefinitionById(Guid.Parse(archetypeProperty.DataTypeGuid));
-                if (dataType == null)
-                {
-                    throw new ArgumentNullException(
-                        $"Unable to find the data type for editor '{archetypeProperty.PropertyEditorAlias}' ({archetypeProperty.DataTypeGuid}) referenced by '{property.Alias}'.");
-                }
+                var errorMessage = $"Unable to find the data type for editor '{archetypeProperty.PropertyEditorAlias}' ({archetypeProperty.DataTypeGuid}) referenced by '{property.Alias}'.";
+                var dataType = GetDataTypeDefinitionById(Guid.Parse(archetypeProperty.DataTypeGuid), errorMessage);
+
                 // add the datatype as a dependency
                 dependencies.Add(new ArtifactDependency(new GuidUdi(Constants.UdiEntityType.DataType, dataType.Key), false, ArtifactDependencyMode.Exist));
 
@@ -134,17 +145,10 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             if (property == null)
                 throw new NullReferenceException($"Property not found: '{alias}'.");
 
-            var prevalues = _dataTypeService.GetPreValuesCollectionByDataTypeId(property.PropertyType.DataTypeDefinitionId).FormatAsDictionary();
-
-            PreValue prevalue = null;
-            //Fetch the Prevalues for the current Property's DataType (if its an 'Archetype config')
-            if (!prevalues.TryGetValue("archetypeconfig", out prevalue) && !prevalues.TryGetValue("archetypeConfig", out prevalue))
-            {
-                throw new InvalidOperationException("Could not find Archetype configuration.");
-            }
-            var archetypePreValue = prevalue == null
+            var strPrevalue = GetArchetypeConfiguration(property.PropertyType.DataTypeDefinitionId);
+            var archetypePreValue = strPrevalue == null
                 ? null
-                : JsonConvert.DeserializeObject<ArchetypePreValue>(prevalue.Value);
+                : JsonConvert.DeserializeObject<ArchetypePreValue>(strPrevalue);
 
             RetrieveAdditionalProperties(ref archetypePreValue);
 
@@ -163,12 +167,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                     continue;
 
                 // get the data type of the property
-                var dataType = _dataTypeService.GetDataTypeDefinitionById(Guid.Parse(archetypeProperty.DataTypeGuid));
-                if (dataType == null)
-                {
-                    throw new ArgumentNullException(
-                        $"Unable to find the data type for editor '{archetypeProperty.PropertyEditorAlias}' ({archetypeProperty.DataTypeGuid}) referenced by '{property.Alias}'.");
-                }
+                var errorMessage = $"Unable to find the data type for editor '{archetypeProperty.PropertyEditorAlias}' ({archetypeProperty.DataTypeGuid}) referenced by '{property.Alias}'.";
+                var dataType = GetDataTypeDefinitionById(Guid.Parse(archetypeProperty.DataTypeGuid), errorMessage);
 
                 // try to convert the value with the macro parser - this is mainly for legacy editors
                 var archetypeValue = _macroParser.ReplaceAttributeValue(archetypeProperty.Value.ToString(), dataType.PropertyEditorAlias, null, Direction.FromArtifact);
@@ -203,11 +203,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             {
                 foreach (var property in fieldset.Properties)
                 {
-                    var dataType = _dataTypeService.GetDataTypeDefinitionById(property.DataTypeGuid);
-
-                    if (dataType == null)
-                        throw new NullReferenceException($"Could not find DataType with guid: '{property.DataTypeGuid}'");
-
+                    var errorMessage = $"Could not find DataType with guid: '{property.DataTypeGuid}'";
+                    var dataType = GetDataTypeDefinitionById(property.DataTypeGuid, errorMessage);
                     property.PropertyEditorAlias = dataType.PropertyEditorAlias;
                 }
             }
@@ -230,15 +227,70 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                             Guid dataTypeGuid;
                             if (Guid.TryParse(propertyInst.DataTypeGuid, out dataTypeGuid) == false)
                                 throw new InvalidOperationException($"Could not parse DataTypeGuid as a guid: '{propertyInst.DataTypeGuid}'.");
-                            var dataTypeDefinition = _dataTypeService.GetDataTypeDefinitionById(dataTypeGuid);
-                            if (dataTypeDefinition == null)
-                                throw new NullReferenceException($"Could not find DataType with guid: '{dataTypeGuid}'");
-                            propertyInst.DataTypeId = dataTypeDefinition.Id;
+                            var errorMessage = $"Could not find DataType with guid: '{dataTypeGuid}'";
+                            var dataType = GetDataTypeDefinitionById(dataTypeGuid, errorMessage);
+                            propertyInst.DataTypeId = dataType.Id;
                             propertyInst.PropertyEditorAlias = property.PropertyEditorAlias;
                         }
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Gets a data type definition from the cache for the specified GUID ID of
+        /// a data type definition.
+        /// </summary>
+        /// <param name="id">
+        /// The GUID ID of the data type definition.
+        /// </param>
+        /// <param name="errorMessage">
+        /// The error message to include with the exception that will be thrown in the case
+        /// that the data type definition cannot be found.
+        /// </param>
+        /// <returns>
+        /// The data type definition.
+        /// </returns>
+        private DataTypeDefinition GetDataTypeDefinitionById(Guid id, string errorMessage)
+        {
+            return dataTypeDefinitionsById.Get(id, dtdKey =>
+            {
+                var dataType = _dataTypeService.GetDataTypeDefinitionById(id);
+                if (dataType == null)
+                {
+                    throw new ArgumentNullException(errorMessage);
+                }
+                return new DataTypeDefinition()
+                {
+                    DatabaseType = dataType.DatabaseType,
+                    Id = dataType.Id,
+                    PropertyEditorAlias = dataType.PropertyEditorAlias
+                };
+            }, dataTypeCacheDuration);
+        }
+
+        /// <summary>
+        /// Returns the Archetype configuration corresponding to the specified data type
+        /// definition.
+        /// </summary>
+        /// <param name="dataTypeDefinitionId">
+        /// The ID of the data type definition.
+        /// </param>
+        /// <returns>
+        /// The Archetype configuration.
+        /// </returns>
+        private string GetArchetypeConfiguration(int dataTypeDefinitionId)
+        {
+            return archetypeConfigPreValuesByDtdId.Get(dataTypeDefinitionId, dtdId =>
+            {
+                PreValue prevalue;
+                var prevalues = _dataTypeService.GetPreValuesCollectionByDataTypeId(dtdId).PreValuesAsDictionary;
+                if (!prevalues.TryGetValue("archetypeconfig", out prevalue) && !prevalues.TryGetValue("archetypeConfig", out prevalue))
+                {
+                    throw new InvalidOperationException("Could not find Archetype configuration.");
+                }
+                return prevalue?.Value;
+            }, TimeSpan.FromSeconds(30));
         }
 
         internal class ArchetypePreValue
@@ -460,5 +512,19 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             [JsonProperty("fileNames")]
             public IEnumerable<string> FileNames { get; set; }
         }
+
+
+        /// <summary>
+        /// A local version of IDataTypeDefinition (to avoid any potential lazy loading/deferred
+        /// execution issues).
+        /// </summary>
+        internal class DataTypeDefinition
+        {
+            public string PropertyEditorAlias { get; set; }
+            public DataTypeDatabaseType DatabaseType { get; set; }
+            public int Id { get; set; }
+            public Guid Key { get; set; }
+        }
+
     }
 }

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/ArchetypeValueConnector.cs
@@ -264,7 +264,8 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                 {
                     DatabaseType = dataType.DatabaseType,
                     Id = dataType.Id,
-                    PropertyEditorAlias = dataType.PropertyEditorAlias
+                    PropertyEditorAlias = dataType.PropertyEditorAlias,
+                    Key = dataType.Key
                 };
             }, dataTypeCacheDuration);
         }


### PR DESCRIPTION
…roperties: https://github.com/umbraco/Umbraco.Cloud.Issues/issues/35

Does this by adding caching (that replenishes every 30 seconds). The plumbing for the caching mechanism is also included.

Should be an improvement upon this pull request: https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/28

Two reasons for that:

* Caches some additional operations that interact with the database.
* The cache is replenished every 30 seconds (useful if a developer is tinkering with data types).

I will test this tomorrow on one of my Umbraco Cloud projects (it's so far entirely untested).