### PR TITLE
Bugfix in SerializeValue when save format is XML

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NuPickersValueConnector.cs
@@ -168,7 +168,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
                 case SaveFormat.XML:
                     var xml = value.Select(x => $"<Picked Key=\"{x.Key}\"><![CDATA[{x.Value}]]></Picked>");
-                    return string.Concat("<Picker>", string.Join(",", xml, "</Picker>"));
+                    return string.Concat("<Picker>", string.Join("", xml), "</Picker>");
 
                 case SaveFormat.CSV:
                 default:


### PR DESCRIPTION
the string concat function was producing wrong xml, this change fixes it.
1. </Picker> was wrongly set as a parameter to string.Join resulting in the xml enumerable to return as a string
2. string.Join should not have a , separator as that would produce malformed xml