### PR TITLE
AB-6447 - Nested content in nested content ends up in a semi corrupt format when deployed

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
@@ -108,17 +108,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                     _logger.Debug<NestedContentValueConnector>("Map " + key + " value '" + row.PropertyValues[key] + "' to '" + parsedValue
                         + "' using " + propValueConnector.GetType() + " for " + propType);
 
-                    // test if the value is a json object (thus could be a nested complex editor)
-                    // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                    JToken jtokenValue = parsedValue != null && parsedValue.ToString().DetectIsJson() ? JToken.Parse(parsedValue.ToString()) : null;
-                    if (jtokenValue != null)
-                    {
-                        parsedValue = jtokenValue;
-                    }
-                    else if (parsedValue != null)
-                    {
-                        parsedValue = parsedValue.ToString();
-                    }
+                    parsedValue = parsedValue.ToString();
 
                     row.PropertyValues[key] = parsedValue;
                 }
@@ -193,17 +183,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                         }
                         else
                         {
-                            // test if the value is a json object (thus could be a nested complex editor)
-                            // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                            var jtokenValue = convertedValue.ToString().DetectIsJson() ? JToken.Parse(convertedValue.ToString()) : null;
-                            if (jtokenValue != null)
-                            {
-                                row.PropertyValues[key] = jtokenValue;
-                            }
-                            else
-                            {
-                                row.PropertyValues[key] = convertedValue;
-                            }
+                            row.PropertyValues[key] = convertedValue;
                         }
                     }
                     else

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
@@ -108,7 +108,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                     _logger.Debug<NestedContentValueConnector>("Map " + key + " value '" + row.PropertyValues[key] + "' to '" + parsedValue
                         + "' using " + propValueConnector.GetType() + " for " + propType);
 
-                    parsedValue = parsedValue.ToString();
+                    parsedValue = parsedValue?.ToString();
 
                     row.PropertyValues[key] = parsedValue;
                 }


### PR DESCRIPTION
# Description
When deploying nested content inside nested content, it would end up in a state where it was readable by the CMS - but not exactly saved in the correct format like the CMS would save it.

Data in this state would however fail to deploy via Deploy, which means that even though everything looks good after an initial deployment from one environment to another, any further deployments from that environment to another, would fail to transfer the data correctly.

While it didn't seem like a always-reproducible error .. it actually is. The cases where it did not seem to reproduce, was when a save had been done via the backoffice on the _deployed_ item before it was redeployed to the next environment. This would cause the CMS to "fix up" the format and then the item could be deployed to the next environment with no issues.

# Fix
The reason why this happens was a check for whether the value is a nested complex value (basically... json). This check is a really old check that I couldn't really find a history of why it needed to be there. It may either be a left-over or it may be because the CMS has been doing things differently in earlier versions.

I've removed this part of the code and tested that nested content in nested content works (tested 3 levels down). I've also tested complex connectors such as dropdowns, checkboxes and editors using prevalues to ensure that these are still working at top level and several levels down in nesting.

# Test
- Create a doctype setup with nested content in nested content in nested content (keep going until you get bored).
- Make sure you have some editors on the nested doctypes so you can see that the doctypes are parsed as doctypes with editors (having values) and not just empty items.
- Insert environments so you have dev+stage+live.
- Create content in the first environment using this doctype - fill in values and make sure to use several levels of nested content.
- Deploy this content item to the second environment and ensure it was deployed correctly.
- Deploy this content item from the second environment to the third environment without saving it first.
- Ensure the content item in the third environment is equal to the one in the first environment.
- Finally check the databases of each environment and verify that the stored values are identical in all environments.