### PR TITLE
adding connector for blocklist property editor.

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -161,15 +161,15 @@
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Properties\VersionInfo.cs" />
+    <Compile Include="ValueConnectors\BlockEditorValueConnector.cs" />
     <Compile Include="ValueConnectors\MultiUrlPickerValueConnector.cs" />
+    <Compile Include="ValueConnectors\BlockListValueConnector.cs" />
     <Compile Include="ValueConnectors\NestedContentValueConnector.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="GridCellValueConnectors\dummy.txt" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="ValueConnectors\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup />
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -40,12 +40,16 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         public string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
         {
             var svalue = value as string;
+
+            // nested values will arrive here as JObject - convert to string to enable reuse of same code as when non-nested.
+            if (value is JObject)
+                svalue = value.ToString();
+
             if (string.IsNullOrWhiteSpace(svalue))
                 return null;
 
             if (svalue.DetectIsJson() == false)
                 return null;
-
             var blockEditorValue = JsonConvert.DeserializeObject<BlockEditorValue>(svalue);
 
             if (blockEditorValue == null)
@@ -178,8 +182,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                 }
             }
 
-            value = JsonConvert.SerializeObject(blockEditorValue);
-            return value;
+            return JObject.FromObject(blockEditorValue);
         }
 
         /// <summary>

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Core;
+using Umbraco.Core.Deploy;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+using Umbraco.Deploy.Connectors.ValueConnectors.Services;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    /// <summary>
+    /// A Deploy connector for BlockEditor based property editors (ie. BlockList)
+    /// </summary>
+    public abstract class BlockEditorValueConnector : IValueConnector
+    {
+        private readonly IContentTypeService _contentTypeService;
+        private readonly Lazy<ValueConnectorCollection> _valueConnectorsLazy;
+        private readonly ILogger _logger;
+
+        public virtual IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockEditor" };
+
+        // cannot inject ValueConnectorCollection directly as it would cause a circular (recursive) dependency,
+        // so we have to inject it lazily and use the lazy value when actually needing it
+        private ValueConnectorCollection ValueConnectors => _valueConnectorsLazy.Value;
+
+        public BlockEditorValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
+        {
+            if (contentTypeService == null) throw new ArgumentNullException(nameof(contentTypeService));
+            if (valueConnectors == null) throw new ArgumentNullException(nameof(valueConnectors));
+            if (logger == null) throw new ArgumentNullException(nameof(logger));
+            _contentTypeService = contentTypeService;
+            _valueConnectorsLazy = valueConnectors;
+            _logger = logger;
+        }
+
+        public string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
+        {
+            var svalue = value as string;
+            if (string.IsNullOrWhiteSpace(svalue))
+                return null;
+
+            if (svalue.DetectIsJson() == false)
+                return null;
+
+            var blockEditorValue = JsonConvert.DeserializeObject<BlockEditorValue>(svalue);
+
+            if (blockEditorValue == null)
+                return null;
+
+            // get all the content types used in block editor items
+            var allContentTypes = blockEditorValue.Data.Select(x => x.ContentTypeKey)
+                .Distinct()
+                .ToDictionary(a => a, a =>
+                {
+                    if (!Guid.TryParse(a, out var keyAsGuid))
+                        throw new InvalidOperationException($"Could not parse ContentTypeKey as GUID {keyAsGuid}.");
+                    return _contentTypeService.Get(keyAsGuid);
+                });
+
+            //Ensure all of these content types are found
+            if (allContentTypes.Values.Any(contentType => contentType == null))
+            {
+                throw new InvalidOperationException($"Could not resolve these content types for the Block Editor property: {string.Join(",", allContentTypes.Where(x => x.Value == null).Select(x => x.Key))}");
+            }
+
+            //Ensure that these content types have dependencies added
+            foreach (var contentType in allContentTypes.Values)
+            {
+                dependencies.Add(new ArtifactDependency(contentType.GetUdi(), false, ArtifactDependencyMode.Match));
+            }
+
+            foreach (var block in blockEditorValue.Data)
+            {
+                var contentType = allContentTypes[block.ContentTypeKey];
+
+                foreach (var key in block.PropertyValues.Keys.ToArray())
+                {
+                    var propType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == key);
+
+                    if (propType == null)
+                    {
+                        _logger.Debug<NestedContentValueConnector>($"No property type found with alias {key} on content type {contentType.Alias}");
+                        continue;
+                    }
+
+                    // fetch the right value connector from the collection of connectors, intended for use with this property type.
+                    // throws if not found - no need for a null check
+                    var propValueConnector = ValueConnectors.Get(propType);
+
+                    // pass the value, property type and the dependencies collection to the connector to get a "artifact" value
+                    var val = block.PropertyValues[key];
+                    object parsedValue = propValueConnector.ToArtifact(val, propType, dependencies);
+
+                    // getting Map image value umb://media/43e7401fb3cd48ceaa421df511ec703c to (nothing) - why?!
+                    _logger.Debug<BlockEditorValueConnector>("Map " + key + " value '" + block.PropertyValues[key] + "' to '" + parsedValue + "' using " + propValueConnector.GetType() + " for " + propType);
+
+                    parsedValue = parsedValue?.ToString();
+
+                    block.PropertyValues[key] = parsedValue;
+                }
+            }
+
+            value = JsonConvert.SerializeObject(blockEditorValue);
+            return (string)value;
+        }
+
+        public object FromArtifact(string value, PropertyType propertyType, object currentValue)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                return value;
+            }
+
+            if (value.DetectIsJson() == false)
+                return value;
+
+            var blockEditorValue = JsonConvert.DeserializeObject<BlockEditorValue>(value);
+
+            if (blockEditorValue == null)
+                return value;
+
+            var allContentTypes = blockEditorValue.Data.Select(x => x.ContentTypeKey)
+                .Distinct()
+                .ToDictionary(a => a, a =>
+                {
+                    if (!Guid.TryParse(a, out var keyAsGuid))
+                        throw new InvalidOperationException($"Could not parse ContentTypeKey as GUID {keyAsGuid}.");
+                    return _contentTypeService.Get(keyAsGuid);
+                });
+
+            //Ensure all of these content types are found
+            if (allContentTypes.Values.Any(contentType => contentType == null))
+            {
+                throw new InvalidOperationException($"Could not resolve these content types for the Block Editor property: {string.Join(",", allContentTypes.Where(x => x.Value == null).Select(x => x.Key))}");
+            }
+
+            foreach (var block in blockEditorValue.Data)
+            {
+                var contentType = allContentTypes[block.ContentTypeKey];
+
+                foreach (var key in block.PropertyValues.Keys.ToArray())
+                {
+                    var innerPropertyType = contentType.CompositionPropertyTypes.FirstOrDefault(x => x.Alias == key);
+
+                    if (innerPropertyType == null)
+                    {
+                        _logger.Debug<BlockEditorValueConnector>($"No property type found with alias {key} on content type {contentType.Alias}");
+                        continue;
+                    }
+
+                    // fetch the right value connector from the collection of connectors, intended for use with this property type.
+                    // throws if not found - no need for a null check
+                    var propValueConnector = ValueConnectors.Get(innerPropertyType);
+
+                    var propertyValue = block.PropertyValues[key];
+
+                    if (propertyValue != null)
+                    {
+                        // pass the artifact value and property type to the connector to get a real value from the artifact
+                        var convertedValue = propValueConnector.FromArtifact(propertyValue.ToString(), innerPropertyType, null);
+                        if (convertedValue == null)
+                        {
+                            block.PropertyValues[key] = null;
+                        }
+                        else
+                        {
+                            block.PropertyValues[key] = convertedValue;
+                        }
+                    }
+                    else
+                    {
+                        block.PropertyValues[key] = propertyValue;
+                    }
+                }
+            }
+
+            value = JsonConvert.SerializeObject(blockEditorValue);
+            return value;
+        }
+
+        /// <summary>
+        /// Strongly typed representation of the stored value for a block editor value
+        /// </summary>
+        /// <example>
+        /// Example JSON:
+        /// <![CDATA[
+        ///     {
+        ///        "layout": {
+        ///            "Umbraco.BlockList": [
+        ///            {
+        ///                "udi": "umb://element/b401bb800a4a48f79786d5079bc47718"
+        ///            }
+        ///            ]
+        ///        },
+        ///        "data": [
+        ///        {
+        ///            "contentTypeKey": "5fe26fff-7163-4805-9eca-960b1f106bb9",
+        ///            "udi": "umb://element/b401bb800a4a48f79786d5079bc47718",
+        ///            "image": "umb://media/e28a0070890848079d5781774c3c5ffb",
+        ///            "text": "hero text",
+        ///            "contentpicker": "umb://document/87478d1efa66413698063f8d00fda1d1"
+        ///        }
+        ///        ]
+        ///     }
+        /// ]]>
+        /// </example>
+        public class BlockEditorValue
+        {
+            /// <summary>
+            /// We do not have to actually handle anything in the layout since it should only contain references to items existing as data.
+            /// JObject is fine for transferring this over.
+            /// </summary>
+            [JsonProperty("layout")]
+            public JObject Layout { get; set; }
+
+            /// <summary>
+            /// This contains all the blocks created in the block editor.
+            /// </summary>
+            [JsonProperty("data")]
+            public IEnumerable<Block> Data { get; set; }
+        }
+
+        public class Block
+        {
+            [JsonProperty("contentTypeKey")]
+            public string ContentTypeKey { get; set; }
+            [JsonProperty("udi")]
+            public string Udi { get; set; }
+
+            /// <summary>
+            /// This is the property values defined on the block.
+            /// These can be anything so we have to use a dictionary to represent them and JsonExtensionData attribute ensures all otherwise unmapped properties are stored here.
+            /// </summary>
+            [JsonExtensionData]
+            public IDictionary<string, object> PropertyValues { get; set; }
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -87,7 +87,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
                     if (propType == null)
                     {
-                        _logger.Debug<NestedContentValueConnector>($"No property type found with alias {key} on content type {contentType.Alias}");
+                        _logger.Debug<BlockEditorValueConnector>("No property type found with alias {Key} on content type {ContentTypeAlias}.", key, contentType.Alias);
                         continue;
                     }
 
@@ -99,8 +99,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                     var val = block.PropertyValues[key];
                     object parsedValue = propValueConnector.ToArtifact(val, propType, dependencies);
 
-                    // getting Map image value umb://media/43e7401fb3cd48ceaa421df511ec703c to (nothing) - why?!
-                    _logger.Debug<BlockEditorValueConnector>("Map " + key + " value '" + block.PropertyValues[key] + "' to '" + parsedValue + "' using " + propValueConnector.GetType() + " for " + propType);
+                    _logger.Debug<BlockEditorValueConnector>("Map {Key} value '{PropertyValue}' to '{ParsedValue}' using {PropValueConnectorType} for {PropTypeAlias}.", key, block.PropertyValues[key], parsedValue, propValueConnector.GetType(), propType.Alias);
 
                     parsedValue = parsedValue?.ToString();
 
@@ -152,7 +151,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
                     if (innerPropertyType == null)
                     {
-                        _logger.Debug<BlockEditorValueConnector>($"No property type found with alias {key} on content type {contentType.Alias}");
+                        _logger.Debug<BlockEditorValueConnector>("No property type found with alias {Key} on content type {ContentTypeAlias}.", key, contentType.Alias);
                         continue;
                     }
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Services;
+using Umbraco.Deploy.Connectors.ValueConnectors.Services;
+
+namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
+{
+    /// <summary>
+    /// A Deploy connector for the BlockList property editor
+    /// </summary>
+    public class BlockListValueConnector : BlockEditorValueConnector
+    {
+        public override IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockList" };
+
+        public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
+            : base(contentTypeService, valueConnectors, logger)
+        { }
+    }
+}


### PR DESCRIPTION
# Description
ValueConnector for transferring Block Editor based content. This will work with the Block List property editor for now.
Depending on where everything goes with the Block Editor based property editors, we may need to move functionality from the abstract connector if it turns out it will actually only apply to the Block List ValueConnector. 

# Test

- Create content using the Block List property editor, having references to both media and other content items.
- Ensure this content is transferred and that dependencies are transferred and handled correctly as well.
- (Further testing could include inspecting that the data is stored in the exact same format on both sides ... I've already done this though)

## Known issues:
Currently there's a bug somewhere causing transfers of nested content inside nested content to throw an exception.
It is not related to this ValueConnector as it applies to both Nested Content and Block Editor. The bug is located somewhere in either Core, Deploy or Examine (something seems to cause Examine to throw an exception). I'm investigating what the cause is.