### PR TITLE
Make ToArtifact/FromArtifact virtual

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -37,7 +37,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             _logger = logger;
         }
 
-        public string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
+        public virtual string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
         {
             var svalue = value as string;
 
@@ -117,7 +117,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             return (string)value;
         }
 
-        public object FromArtifact(string value, PropertyType propertyType, object currentValue)
+        public virtual object FromArtifact(string value, PropertyType propertyType, object currentValue)
         {
             if (string.IsNullOrWhiteSpace(value))
             {


### PR DESCRIPTION
Makes the ToArtifact and FromArtifact virtual so that they can be overridden to allow for extra processing when used by custom block list editor prop editors that store additional info that would need more work performed on them