### PR TITLE
Updated to v9/net 5.

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/Properties/VersionInfo.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Properties/VersionInfo.cs
@@ -8,7 +8,7 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-[assembly: System.Reflection.AssemblyInformationalVersion("4.0.0")]
-[assembly: System.Reflection.AssemblyVersion("4.0.0")]
+[assembly: System.Reflection.AssemblyInformationalVersion("9.0.0-beta001")]
+[assembly: System.Reflection.AssemblyVersion("9.0.0")]
 
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
+++ b/src/Umbraco.Deploy.Contrib.Connectors/Umbraco.Deploy.Contrib.Connectors.csproj
@@ -3,16 +3,10 @@
         <AssemblyName>Umbraco.Deploy.Contrib.Connectors</AssemblyName>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>Umbraco.Deploy.Contrib.Connectors</RootNamespace>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
-        <Content Include="GridCellValueConnectors\dummy.txt" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <PackageReference Include="UmbracoDeploy.Core">
-            <Version>4.1.2</Version>
-        </PackageReference>
+        <PackageReference Include="Umbraco.Deploy.Core" Version="9.0.0-beta001" />
     </ItemGroup>
 </Project>

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
-using Umbraco.Core.Logging;
-using Umbraco.Core.Services;
-using Umbraco.Deploy.Connectors.ValueConnectors.Services;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Deploy.Core.Connectors.ValueConnectors.Services;
 
 namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 {
@@ -13,7 +13,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
     {
         public override IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockList" };
 
-        public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
+        public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger<BlockListValueConnector> logger)
             : base(contentTypeService, valueConnectors, logger)
         { }
     }

--- a/src/Umbraco.Deploy.Contrib.Tests/Properties/AssemblyInfo.cs
+++ b/src/Umbraco.Deploy.Contrib.Tests/Properties/AssemblyInfo.cs
@@ -13,4 +13,4 @@ using System.Runtime.InteropServices;
 [assembly: ComVisible(false)]
 [assembly: Guid("48b09241-9c44-47ef-b4df-397b39a631dc")]
 
-[assembly: AssemblyVersion("4.0.0")]
+[assembly: AssemblyVersion("9.0.0")]

--- a/src/Umbraco.Deploy.Contrib.Tests/TestHelpers/MockedMedia.cs
+++ b/src/Umbraco.Deploy.Contrib.Tests/TestHelpers/MockedMedia.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using Umbraco.Core.Models;
+using Umbraco.Cms.Core.Models;
 
 namespace Umbraco.Deploy.Contrib.Tests.TestHelpers
 {

--- a/src/Umbraco.Deploy.Contrib.Tests/Umbraco.Deploy.Contrib.Tests.csproj
+++ b/src/Umbraco.Deploy.Contrib.Tests/Umbraco.Deploy.Contrib.Tests.csproj
@@ -3,14 +3,8 @@
         <AssemblyName>Umbraco.Deploy.Contrib.Connectors.Tests</AssemblyName>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <RootNamespace>Umbraco.Deploy.Contrib.Connectors.Tests</RootNamespace>
-        <TargetFramework>net472</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="UmbracoDeploy.Core">
-            <Version>4.1.2</Version>
-        </PackageReference>
-    </ItemGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\Umbraco.Deploy.Contrib.Connectors\Umbraco.Deploy.Contrib.Connectors.csproj" />


### PR DESCRIPTION
Updated the code to depend on V9 of Deploy.

For review, a visual inspection is sufficient for now - further testing will be happening later on the different property editors covered here.  I've also taken a reference on a local NuGet package, which isn't yet up on a feed, so you won't actually be able to compile it locally.

Don't believe there's any points to flag - there's not much code and it all came over with just the usual updates needed (namespaces, logging, method signatures, dependencies).