### PR TITLE
Fixes DTGE connector to handle complex property editors such as nested content.

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
@@ -91,7 +91,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
                 docTypeGridEditorContent.Value[propertyType.Alias] = parsedValue;
             }
 
-            var resolvedValue = JsonConvert.SerializeObject(docTypeGridEditorContent);
+            var resolvedValue = JsonConvert.SerializeObject(docTypeGridEditorContent, Formatting.None);
 
             _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - ResolvedValue - {resolvedValue}");
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
@@ -145,7 +145,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
 
                 // throws if not found - no need for a null check
                 var propValueConnector = ValueConnectors.Get(propertyType);
-                var convertedValue = propValueConnector.FromArtifact(value.ToString(), propertyType, "");
+                var convertedValue = propValueConnector.FromArtifact(value.ToString(), propertyType, string.Empty);
 
                 JToken jtokenValue = null;
                 if (IsJson(convertedValue))

--- a/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
@@ -66,7 +66,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
                 _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - PropertyTypeAlias - {propertyType.Alias}");
 
                 // test if there's a value for the given property
-                if (IsValueNull(docTypeGridEditorContent, propertyType, out var value))
+                if (!TryGetValue(docTypeGridEditorContent, propertyType, out var value))
                 {
                     continue;
                 }
@@ -77,43 +77,18 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
                     continue;
                 }
 
-                JToken jtokenValue = null;
-                var parsedValue = string.Empty;
-
                 // throws if not found - no need for a null check
                 var propValueConnector = ValueConnectors.Get(propertyType);
 
-                _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - PropertyValueConnectorAlias - {propValueConnector.PropertyEditorAliases}");
+                _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - PropertyValueConnectorAlias - {string.Join(", ", propValueConnector.PropertyEditorAliases)}");
                 _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - propertyTypeValue - {value}");
 
-                //properties like MUP / Nested Content seems to be in json and it breaks, so pass it back as jtokenValue right away
-                if (IsJson(value))
-                {
-                    jtokenValue = GetJTokenValue(value);
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - Inner JtokenValue - Eg MUP/NestedContent {jtokenValue}");
-                }
-                else
-                {
-                    parsedValue = propValueConnector.ToArtifact(value, propertyType, dependencies);
+                //properties like MUP / Nested Content are JSON, we need to convert to string for the conversion to artifact
+                string parsedValue = propValueConnector.ToArtifact(IsJson(value) ? value.ToString() : value, propertyType, dependencies);
 
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - ParsedValue - {parsedValue}");
+                _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - ParsedValue - {parsedValue}");
 
-                    if (IsJson(parsedValue))
-                    {
-                        // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                        jtokenValue = GetJTokenValue(parsedValue);
-                    }
-                }
-
-                if (jtokenValue != null)
-                {
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"GetValue - JtokenValue - {jtokenValue}");
-                    docTypeGridEditorContent.Value[propertyType.Alias] = jtokenValue;
-                }
-                else
-                {
-                    docTypeGridEditorContent.Value[propertyType.Alias] = parsedValue;
-                }
+                docTypeGridEditorContent.Value[propertyType.Alias] = parsedValue;
             }
 
             var resolvedValue = JsonConvert.SerializeObject(docTypeGridEditorContent);
@@ -160,8 +135,6 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
 
             foreach (var propertyType in propertyTypes)
             {
-                JToken jtokenValue = null;
-
                 _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - PropertyEditorAlias -- {propertyType.PropertyEditorAlias}");
 
                 if (!docTypeGridEditorContent.Value.TryGetValue(propertyType.Alias, out object value) || value == null)
@@ -172,59 +145,25 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
 
                 // throws if not found - no need for a null check
                 var propValueConnector = ValueConnectors.Get(propertyType);
-                propValueConnector.FromArtifact(value.ToString(), propertyType, "");
+                var convertedValue = propValueConnector.FromArtifact(value.ToString(), propertyType, "");
 
-                _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - PropertyValueConnecterType - {propValueConnector.GetType()}");
-                _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - Value - {value}");
-
-                // test if there's a value for the given property
-                object convertedValue;
-                //don't convert if it's json (MUP/Nested) / udi (Content/Media/Multi Pickers) / guid (form picker) / rte / textstring values
-                if (IsJson(value) || IsUdi(value) || IsGuid(value) || IsText(propertyType.PropertyEditorAlias))
+                JToken jtokenValue = null;
+                if (IsJson(convertedValue))
                 {
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - IsJsonValue / IsUdiValue / IsGuidValue / IsTextValue - {value}");
-                    convertedValue = CleanValue(propertyType.PropertyEditorAlias, value);
+                    // test if the value is a json object (thus could be a nested complex editor)
+                    // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
+                    jtokenValue = GetJTokenValue(convertedValue);
+                }
+
+                if (jtokenValue != null)
+                {
+                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - jtokenValue - {jtokenValue}");
+                    docTypeGridEditorContent.Value[propertyType.Alias] = jtokenValue;
                 }
                 else
                 {
-                    //using mockContent to get the converted values
-                    var mockProperty = new Property(propertyType);
-                    var mockContent = new Content("mockContentGrid", -1, new ContentType(-1), new PropertyCollection(new List<Property> { mockProperty }));
-                    convertedValue = mockContent.GetValue(mockProperty.Alias);
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - ConvertedValue - Before - {convertedValue}");
-                }
-
-                // integers needs to be converted into strings for DTGE to work
-                if (convertedValue is int)
-                {
-                    docTypeGridEditorContent.Value[propertyType.Alias] = convertedValue.ToString();
-                }
-                else if (convertedValue == null)
-                {
-                    //Assign the null back - otherwise the check for JSON will fail as we cant convert a null to a string
-                    //NOTE: LinkPicker2 for example if no link set is returning a null as opposed to empty string
-                    docTypeGridEditorContent.Value[propertyType.Alias] = null;
-                }
-                else
-                {
-                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - ConvertedValue - After - {convertedValue}");
-
-                    if (IsJson(convertedValue))
-                    {
-                        // test if the value is a json object (thus could be a nested complex editor)
-                        // if that's the case we'll need to add it as a json object instead of string to avoid it being escaped
-                        jtokenValue = GetJTokenValue(convertedValue);
-                    }
-
-                    if (jtokenValue != null)
-                    {
-                        _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - jtokenValue - {jtokenValue}");
-                        docTypeGridEditorContent.Value[propertyType.Alias] = jtokenValue;
-                    }
-                    else
-                    {
-                        docTypeGridEditorContent.Value[propertyType.Alias] = convertedValue;
-                    }
+                    _logger.Debug<DocTypeGridEditorCellValueConnector>($"SetValue - convertedValue - {convertedValue}");
+                    docTypeGridEditorContent.Value[propertyType.Alias] = convertedValue;
                 }
             }
 
@@ -236,24 +175,6 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
         private JToken GetJTokenValue(object value) => value != null && IsJson(value) ? JToken.Parse(value.ToString()) : null;
 
         private bool IsJson(object value) => value != null && value.ToString().DetectIsJson();
-
-        private bool IsGuid(object value) => Guid.TryParse(value.ToString(), out _);
-
-        private bool IsUdi(object value) =>
-            //for picker like content/media either single or multi, it comes with udi values
-            value.ToString().Contains("umb://");
-
-        private bool IsText(string editorAlias) =>
-            //if it's either RTE / Textstring data type
-            IsRichtext(editorAlias) || IsTextstring(editorAlias);
-
-        private bool IsRichtext(string editorAlias) => editorAlias.InvariantEquals("Umbraco.TinyMCE");
-
-        private bool IsTextstring(string editorAlias) => editorAlias.InvariantEquals("Umbraco.TextBox");
-
-        private string CleanValue(string editorAlias, object value) =>
-            //can't tell why textstring have got a weird character 's' in front coming from deploy? so removing first char if that's the case
-            IsTextstring(editorAlias) ? value.ToString().Substring(1) : value.ToString();
 
         private bool AddUdiDependency(ICollection<ArtifactDependency> dependencies, object value)
         {
@@ -267,15 +188,15 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
             return false;
         }
 
-        private bool IsValueNull(DocTypeGridEditorValue docTypeGridEditorContent, PropertyType propertyType, out object objVal)
+        private bool TryGetValue(DocTypeGridEditorValue docTypeGridEditorContent, PropertyType propertyType, out object objVal)
         {
             if (!docTypeGridEditorContent.Value.TryGetValue(propertyType.Alias, out objVal) || objVal == null)
             {
                 _logger.Debug<DocTypeGridEditorCellValueConnector>("GetValue - Value is null");
-                return true;
+                return false;
             }
 
-            return false;
+            return true;
         }
 
         private class DocTypeGridEditorValue

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
@@ -41,7 +41,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
         public string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
         {
-            _logger.Info<NestedContentValueConnector>("Converting {PropertyType} to artifact.", propertyType.Alias);
+            _logger.Debug<NestedContentValueConnector>("Converting {PropertyType} to artifact.", propertyType.Alias);
             var svalue = value as string;
 
             if (string.IsNullOrWhiteSpace(svalue))
@@ -126,13 +126,13 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             }
 
             value = JsonConvert.SerializeObject(nestedContent);
-            _logger.Info<BlockEditorValueConnector>("Finished converting {PropertyType} to artifact.", propertyType.Alias);
+            _logger.Debug<BlockEditorValueConnector>("Finished converting {PropertyType} to artifact.", propertyType.Alias);
             return (string)value;
         }
 
         public object FromArtifact(string value, PropertyType propertyType, object currentValue)
         {
-            _logger.Info<NestedContentValueConnector>("Converting {PropertyType} from artifact.", propertyType.Alias);
+            _logger.Debug<NestedContentValueConnector>("Converting {PropertyType} from artifact.", propertyType.Alias);
             if (string.IsNullOrWhiteSpace(value))
             {
                 _logger.Warn<NestedContentValueConnector>($"Value is null or whitespace. Skipping conversion from artifact.");
@@ -219,7 +219,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             // Note: NestedContent does not use formatting when serializing JSON values.
             value = JArray.FromObject(nestedContent).ToString(Formatting.None);
 
-            _logger.Info<NestedContentValueConnector>("Finished converting {PropertyType} from artifact.", propertyType.Alias);
+            _logger.Debug<NestedContentValueConnector>("Finished converting {PropertyType} from artifact.", propertyType.Alias);
 
             return value;
         }


### PR DESCRIPTION
This PR makes some changes to the `DocTypeGridEditorCellValueConnector` to handle when property editors such as nested content are used within it, as raised in [issue 82](https://github.com/umbraco/Umbraco.Deploy.Issues/issues/82).

The main change is to lean more on the dependent value connectors for the specific properties to parse the values rather than using parsing logic in the service connector.  Having done so this looks successfully and correctly transfer both simple properties such as text strings and RTEs, but also complex ones like nested content, multi-node tree picker and multi URL picker.

To Test:

- In test projects for Deploy, install [Doc Type Grid Editor](https://our.umbraco.com/packages/backoffice-extensions/doc-type-grid-editor/).
- Build the code from this PR and copy the `Umbraco.Deploy.Contrib.Connectors.dll` into the test projects
- Set up a grid editor using a doc type that includes various different properties, including complex ones like nested content
- Synchronise the schema between environments,
- Attempt to transfer and restore content between environments and check the operations succeed and the values in the destination environment are correct.

 