### PR TITLE
Null check `blockEditorValue.Settings` before concatenating with `blockEditorValue.Content`

### DIFF
--- a/src/Umbraco.Deploy.Contrib/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib/ValueConnectors/BlockEditorValueConnector.cs
@@ -69,7 +69,7 @@ namespace Umbraco.Deploy.Contrib.ValueConnectors
                 return null;
             }
 
-            var allBlocks = blockEditorValue.Content.Concat(blockEditorValue.Settings).ToList();
+            var allBlocks = blockEditorValue.Content.Concat(blockEditorValue.Settings ?? Enumerable.Empty<Block>()).ToList();
 
             // get all the content types used in block editor items
             var allContentTypes = allBlocks.Select(x => x.ContentTypeKey)
@@ -148,7 +148,7 @@ namespace Umbraco.Deploy.Contrib.ValueConnectors
             if (blockEditorValue == null)
                 return value;
 
-            var allBlocks = blockEditorValue.Content.Concat(blockEditorValue.Settings).ToList();
+            var allBlocks = blockEditorValue.Content.Concat(blockEditorValue.Settings ?? Enumerable.Empty<Block>()).ToList();
 
             var allContentTypes = allBlocks.Select(x => x.ContentTypeKey)
                 .Distinct()


### PR DESCRIPTION
It's possible that a block editor value may have no settings collection, especially for 3rd party editors that don't need settings, so we need to null check before concatenating all nodes.