### PR TITLE
Optimise content type lookups in connectors

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/DeployContribConstants.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/DeployContribConstants.cs
@@ -4,7 +4,10 @@
     {
         public static class CacheKeys
         {
-            public const string DeployConnectorContentTypeDependenciesFormat = "DeployConnectorContentTypeDependencies_{0}";
+            // TODO (V10): Remove this and use the value defined in DeployConstants.CacheKeys
+            public const string DeployConnectorCachePrefix = "DeployConnectorCache";
+
+            public const string DeployConnectorCacheContentTypesFormat = DeployConnectorCachePrefix + "ContentTypes_{0}";
         }
     }
 }

--- a/src/Umbraco.Deploy.Contrib.Connectors/DeployContribConstants.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/DeployContribConstants.cs
@@ -1,0 +1,10 @@
+﻿namespace Umbraco.Deploy.Contrib.Connectors
+{
+    internal static class DeployContribConstants
+    {
+        public static class CacheKeys
+        {
+            public const string DeployConnectorContentTypeDependenciesFormat = "DeployConnectorContentTypeDependencies_{0}";
+        }
+    }
+}

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Web;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Umbraco.Core;
@@ -22,6 +23,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         private readonly Lazy<ValueConnectorCollection> _valueConnectorsLazy;
         private readonly ILogger _logger;
         private readonly IAppCache _requestCache;
+        private readonly IAppPolicyCache _runtimeCache;
 
         public virtual IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockEditor" };
 
@@ -46,6 +48,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
             _valueConnectorsLazy = valueConnectors;
             _logger = logger;
             _requestCache = appCaches.RequestCache;
+            _runtimeCache = appCaches.RuntimeCache;
         }
 
         public virtual string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies)
@@ -147,15 +150,16 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
             // If we've requested this set of content types within the request, get from cache rather than going to the database again.
             // This is useful as this method can be called multiple times in a save/publish operation.
-            var cacheKey = string.Format(DeployContribConstants.CacheKeys.DeployConnectorContentTypeDependenciesFormat, string.Join(",", allBlockContentTypeKeys));
+            var cacheKey = string.Format(DeployContribConstants.CacheKeys.DeployConnectorCacheContentTypesFormat, string.Join(",", allBlockContentTypeKeys));
 
-            // If we're on a background thread (e.g. for a content transfer), the request cache won't exist and we'll fall through to the database retrieval.
-            var contentTypes = _requestCache.GetCacheItem(
-                cacheKey,
-                () => allBlockContentTypeKeys
-                          .ToDictionary(x => x.ToString(), x => _contentTypeService.Get(x)));
-
-            return contentTypes;
+            // If we're on a background thread (e.g. for a content transfer), the request cache won't exist and we would fall through to the database retrieval.
+            // So instead we'll use the runtime cache (which will be cleared by Deploy between each background operation).
+            Func<Dictionary<string, IContentType>> getContentTypes = () =>
+                allBlockContentTypeKeys
+                    .ToDictionary(x => x.ToString(), x => _contentTypeService.Get(x));
+            return HttpContext.Current != null
+                ? _requestCache.GetCacheItem(cacheKey, getContentTypes)
+                : _runtimeCache.GetCacheItem(cacheKey, getContentTypes);
         }
 
         private Guid ParseAsGuid(string key)

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Umbraco.Core.Cache;
 using Umbraco.Core.Logging;
 using Umbraco.Core.Services;
 using Umbraco.Deploy.Connectors.ValueConnectors.Services;
@@ -13,8 +14,15 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
     {
         public override IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockList" };
 
+        // TODO (V10): Remove this constructor.
+        [Obsolete("Please use the constructor taking all parameters. This constructor will be removed in a future version.")]
         public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
-            : base(contentTypeService, valueConnectors, logger)
+            : this(contentTypeService, valueConnectors, logger, Umbraco.Core.Composing.Current.AppCaches)
+        {
+        }
+
+        public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger, AppCaches appCaches)
+            : base(contentTypeService, valueConnectors, logger, appCaches)
         { }
     }
 }


### PR DESCRIPTION
We've a couple of connectors in here - for the block list and nested content - that need to look up content types.  This is done multiple times in the context of a back-office save or a content transfer to deploy operation.

To optimise this I've added some caching, so it'll only make the request once per operation.

- I'm using the request cache if available (as it is when saving in the back-office), as this is really the behaviour we want, to cache for the context of the request and not beyond that.
- For a content transfer though, this happens in a background thread and so the request cache isn't available.  So instead here I'm using the runtime cache.
    - There's [another PR for Deploy](https://github.com/umbraco/Umbraco-Deploy/pull/657) that clears this between operations, so again we don't cache the data for longer than we want to.