### PR TITLE
Add additional caching using IContextCache

### DIFF
--- a/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/GridCellValueConnectors/DocTypeGridEditorCellValueConnector.cs
@@ -25,7 +25,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.GridCellValueConnectors
 
         public DocTypeGridEditorCellValueConnector(ILogger logger, IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors)
         {
-            _logger = logger;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _contentTypeService = contentTypeService ?? throw new ArgumentNullException(nameof(contentTypeService));
             _valueConnectorsLazy = valueConnectors ?? throw new ArgumentNullException(nameof(valueConnectors));
         }

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -26,10 +26,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         private readonly ILogger _logger;
 
         /// <inheritdoc />
-        public override IEnumerable<string> PropertyEditorAliases { get; } = new[]
-        {
-            "Umbraco.BlockEditor"
-        };
+        public override IEnumerable<string> PropertyEditorAliases { get; } = Enumerable.Empty<string>();
 
         // cannot inject ValueConnectorCollection directly as it would cause a circular (recursive) dependency,
         // so we have to inject it lazily and use the lazy value when actually needing it

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockEditorValueConnector.cs
@@ -37,12 +37,9 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
         public BlockEditorValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
         {
-            if (contentTypeService == null) throw new ArgumentNullException(nameof(contentTypeService));
-            if (valueConnectors == null) throw new ArgumentNullException(nameof(valueConnectors));
-            if (logger == null) throw new ArgumentNullException(nameof(logger));
-            _contentTypeService = contentTypeService;
-            _valueConnectorsLazy = valueConnectors;
-            _logger = logger;
+            _contentTypeService = contentTypeService ?? throw new ArgumentNullException(nameof(contentTypeService));
+            _valueConnectorsLazy = valueConnectors ?? throw new ArgumentNullException(nameof(valueConnectors));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public override string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/BlockListValueConnector.cs
@@ -11,7 +11,10 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
     /// </summary>
     public class BlockListValueConnector : BlockEditorValueConnector
     {
-        public override IEnumerable<string> PropertyEditorAliases => new[] { "Umbraco.BlockList" };
+        public override IEnumerable<string> PropertyEditorAliases { get; } = new[]
+        {
+            "Umbraco.BlockList"
+        };
 
         public BlockListValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
             : base(contentTypeService, valueConnectors, logger)

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MultiUrlPickerValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MultiUrlPickerValueConnector.cs
@@ -85,7 +85,7 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
                             : UmbracoObjectTypes.Document;
                         var entityType = isMedia ? Constants.UdiEntityType.Media : Constants.UdiEntityType.Document;
 
-                        var guidAttempt = _entityService.GetKey(intId, objectTypeId);
+                        var guidAttempt = contextCache.GetEntityKeyById(_entityService, intId, objectTypeId);
                         if (guidAttempt.Success == false)
                             continue;
 

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MultiUrlPickerValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/MultiUrlPickerValueConnector.cs
@@ -50,11 +50,9 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
         /// <param name="logger"></param>
         public MultiUrlPickerValueConnector(IEntityService entityService, IMediaService mediaService, ILogger logger)
         {
-            if (entityService == null) throw new ArgumentNullException(nameof(entityService));
-            if (mediaService == null) throw new ArgumentNullException(nameof(mediaService));
-            _entityService = entityService;
-            _mediaService = mediaService;
-            _logger = logger;
+            _entityService = entityService ?? throw new ArgumentNullException(nameof(entityService));
+            _mediaService = mediaService ?? throw new ArgumentNullException(nameof(mediaService));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public sealed override string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)

--- a/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
+++ b/src/Umbraco.Deploy.Contrib.Connectors/ValueConnectors/NestedContentValueConnector.cs
@@ -41,12 +41,9 @@ namespace Umbraco.Deploy.Contrib.Connectors.ValueConnectors
 
         public NestedContentValueConnector(IContentTypeService contentTypeService, Lazy<ValueConnectorCollection> valueConnectors, ILogger logger)
         {
-            if (contentTypeService == null) throw new ArgumentNullException(nameof(contentTypeService));
-            if (valueConnectors == null) throw new ArgumentNullException(nameof(valueConnectors));
-            if (logger == null) throw new ArgumentNullException(nameof(logger));
-            _contentTypeService = contentTypeService;
-            _valueConnectorsLazy = valueConnectors;
-            _logger = logger;
+            _contentTypeService = contentTypeService ?? throw new ArgumentNullException(nameof(contentTypeService));
+            _valueConnectorsLazy = valueConnectors ?? throw new ArgumentNullException(nameof(valueConnectors));
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
 
         public sealed override string ToArtifact(object value, PropertyType propertyType, ICollection<ArtifactDependency> dependencies, IContextCache contextCache)


### PR DESCRIPTION
Continuing on PR https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/54, this adds one additional cached entity key lookup in `MultiUrlPickerValueConnector`. Once the additional context cache helpers in Deploy (PR https://github.com/umbraco/Umbraco-Deploy/pull/701) are merged/released, we can bump the dependency version and also add caching to the `IMediaService.GetMediaByPath` and `IMediaService.GetById` calls 👍🏻

I've also added/updated the constructor null-checks to use throw expressions and removed the non-existent `Umbraco.BlockEditor` alias from the abstract `BlockEditorValueConnector` as mentioned in https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/54#discussion_r953517991.