### PR TITLE
Skip empty pre-values

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/PreValuesDataTypeArtifactJsonMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/PreValuesDataTypeArtifactJsonMigrator.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Newtonsoft.Json.Linq;
 using Semver;
 using Umbraco.Core;
@@ -30,10 +31,17 @@ namespace Umbraco.Deploy.Contrib.Migrators.Legacy
 
                     // Convert pre-value serialized JSON to actual JSON objects/arrays
                     if (propertyValue.Type == JTokenType.String &&
-                        propertyValue.Value<string>() is string json &&
-                        json.DetectIsJson())
+                        propertyValue.Value<string>() is string value)
                     {
-                        propertyValue = JToken.Parse(json);
+                        if (string.IsNullOrEmpty(value))
+                        {
+                            // Skip empty value
+                            continue;
+                        }
+                        else if (value.DetectIsJson())
+                        {
+                            propertyValue = JToken.Parse(value);
+                        }
                     }
 
                     configuration.Add(property.Name, propertyValue);


### PR DESCRIPTION
While testing a Deploy import from v7 using the legacy migrators, I noticed some data type pre-values/configuration values (for boolean values like `multiPicker`) had empty values, which causes the subsequent deserialization of the configuration object to fail.

This is fixed by skipping these empty values when pre-values are migrated to configuration in `PreValuesDataTypeArtifactJsonMigrator` 💪🏻 