### PR TITLE
v14: Fix commented out migrators

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/CheckBoxListDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/CheckBoxListDataTypeArtifactMigrator.cs
@@ -1,47 +1,40 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="Constants.PropertyEditors.Aliases.CheckBoxList" /> editor configuration from Umbraco 7 to <see cref="ValueListConfiguration" />.
-///// </summary>
-//public class CheckBoxListDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<ValueListConfiguration>
-//{
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="CheckBoxListDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public CheckBoxListDataTypeArtifactMigrator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(Constants.PropertyEditors.Aliases.CheckBoxList, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="Constants.PropertyEditors.Aliases.CheckBoxList" /> editor configuration from Umbraco 7 to <see cref="ValueListConfiguration" />.
+/// </summary>
+public class CheckBoxListDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<ValueListConfiguration>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckBoxListDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public CheckBoxListDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.CheckBoxList, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override ValueListConfiguration? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        var toConfiguration = new ValueListConfiguration();
+    /// <inheritdoc />
+    protected override ValueListConfiguration? MigrateConfigurationObject(IDictionary<string, object> fromConfiguration)
+    {
+        var toConfiguration = new ValueListConfiguration();
 
-//        foreach (var (key, value) in fromConfiguration)
-//        {
-//            if (int.TryParse(key, out var id) && value is not null)
-//            {
-//                toConfiguration.Items.Add(new ValueListConfiguration.ValueListItem()
-//                {
-//                    Id = id,
-//                    Value = value.ToString()
-//                });
-//            }
-//        }
+        foreach (var (key, value) in fromConfiguration)
+        {
+            if (int.TryParse(key, out _) && value is string itemValue)
+            {
+                toConfiguration.Items.Add(itemValue);
+            }
+        }
 
-//        return toConfiguration;
-//    }
-
-//    /// <inheritdoc />
-//    protected override ValueListConfiguration? GetDefaultConfiguration()
-//        => new ValueListConfiguration();
-//}
+        return toConfiguration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/ColorPickerAliasDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/ColorPickerAliasDataTypeArtifactMigrator.cs
@@ -1,51 +1,51 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.ColorPicker" /> and the configuration from Umbraco 7 to <see cref="ColorPickerConfiguration" />.
-///// </summary>
-//public class ColorPickerAliasDataTypeArtifactMigrator : ReplaceDataTypeArtifactMigratorBase<ColorPickerConfiguration>
-//{
-//    private const string FromEditorAlias = "Umbraco.ColorPickerAlias";
-//    private const string TrueValue = "1";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.ColorPicker" /> and the configuration from Umbraco 7 to <see cref="ColorPickerConfiguration" />.
+/// </summary>
+public class ColorPickerAliasDataTypeArtifactMigrator : ReplaceDataTypeArtifactMigratorBase<ColorPickerConfiguration>
+{
+    private const string FromEditorAlias = "Umbraco.ColorPickerAlias";
+    private const string TrueValue = "1";
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="ColorPickerAliasDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public ColorPickerAliasDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.ColorPicker, propertyEditors, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ColorPickerAliasDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public ColorPickerAliasDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.ColorPicker, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override ColorPickerConfiguration? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        var toConfiguration = new ColorPickerConfiguration();
+    /// <inheritdoc />
+    protected override ColorPickerConfiguration? MigrateConfigurationObject(IDictionary<string, object> fromConfiguration)
+    {
+        var toConfiguration = new ColorPickerConfiguration();
 
-//        foreach (var (key, value) in fromConfiguration)
-//        {
-//            if (key == "useLabel")
-//            {
-//                toConfiguration.UseLabel = TrueValue.Equals(value);
-//            }
-//            else if (int.TryParse(key, out var id) && value is not null)
-//            {
-//                toConfiguration.Items.Add(new ValueListConfiguration.ValueListItem()
-//                {
-//                    Id = id,
-//                    Value = value.ToString()
-//                });
-//            }
-//        }
+        foreach (var (key, value) in fromConfiguration)
+        {
+            if (key == "useLabel")
+            {
+                toConfiguration.UseLabel = TrueValue.Equals(value);
+            }
+            else if (int.TryParse(key, out _) && value is string itemValue)
+            {
+                toConfiguration.Items.Add(new ColorPickerConfiguration.ColorPickerItem()
+                {
+                    Label = itemValue,
+                    Value = itemValue,
+                });
+            }
+        }
 
-//        return toConfiguration;
-//    }
-//}
+        return toConfiguration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownDataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public class DropDownDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.DropDown";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public class DropDownDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropDown";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => false;
+    /// <inheritdoc />
+    protected override bool Multiple => false;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropDownDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public DropDownDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public DropDownDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownFlexibleDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownFlexibleDataTypeArtifactMigrator.cs
@@ -1,59 +1,58 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the configuration of the <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> editor from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public class DropDownFlexibleDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<DropDownFlexibleConfiguration>
-//{
-//    private const string TrueValue = "1";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the configuration of the <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> editor from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public class DropDownFlexibleDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<DropDownFlexibleConfiguration>
+{
+    private const string TrueValue = "1";
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropDownFlexibleDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public DropDownFlexibleDataTypeArtifactMigrator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(Constants.PropertyEditors.Aliases.DropDownListFlexible, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownFlexibleDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public DropDownFlexibleDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.DropDownListFlexible, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override DropDownFlexibleConfiguration? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        var toConfiguration = new DropDownFlexibleConfiguration()
-//        {
-//            Multiple = true
-//        };
+    /// <inheritdoc />
+    protected override DropDownFlexibleConfiguration? MigrateConfigurationObject(IDictionary<string, object> fromConfiguration)
+    {
+        var toConfiguration = new DropDownFlexibleConfiguration()
+        {
+            Multiple = true
+        };
 
-//        foreach (var (key, value) in fromConfiguration)
-//        {
-//            if (key == "multiple")
-//            {
-//                toConfiguration.Multiple = TrueValue.Equals(value);
-//            }
-//            else if (int.TryParse(key, out var id) && value is not null)
-//            {
-//                toConfiguration.Items.Add(new ValueListConfiguration.ValueListItem()
-//                {
-//                    Id = id,
-//                    Value = value.ToString()
-//                });
-//            }
-//        }
+        foreach (var (key, value) in fromConfiguration)
+        {
+            if (key == "multiple")
+            {
+                toConfiguration.Multiple = TrueValue.Equals(value);
+            }
+            else if (int.TryParse(key, out _) && value is string itemValue)
+            {
+                toConfiguration.Items.Add(itemValue);
+            }
+        }
 
-//        return toConfiguration;
-//    }
+        return toConfiguration;
+    }
 
-//    /// <inheritdoc />
-//    protected override DropDownFlexibleConfiguration? GetDefaultConfiguration()
-//        => new DropDownFlexibleConfiguration()
-//        {
-//            Multiple = true
-//        };
-//}
+    /// <inheritdoc />
+    protected override IDictionary<string, object> GetDefaultConfiguration(IConfigurationEditor configurationEditor)
+    {
+        var configuration = base.GetDefaultConfiguration(configurationEditor);
+        configuration["multiple"] = true;
+
+        return configuration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownMultipleDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownMultipleDataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public class DropDownMultipleDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.DropDownMultiple";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public class DropDownMultipleDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropDownMultiple";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => true;
+    /// <inheritdoc />
+    protected override bool Multiple => true;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropDownMultipleDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public DropDownMultipleDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownMultipleDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public DropDownMultipleDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownReplaceDataTypeArtifactMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropDownReplaceDataTypeArtifactMigratorBase.cs
@@ -1,74 +1,67 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the editor alias with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public abstract class DropDownReplaceDataTypeArtifactMigratorBase : ReplaceDataTypeArtifactMigratorBase<DropDownFlexibleConfiguration>
-//{
-//    private const string TrueValue = "1";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the editor alias with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public abstract class DropDownReplaceDataTypeArtifactMigratorBase : ReplaceDataTypeArtifactMigratorBase<DropDownFlexibleConfiguration>
+{
+    private const string TrueValue = "1";
 
-//    /// <summary>
-//    /// Gets a value indicating whether the configuration allows multiple items to be selected.
-//    /// </summary>
-//    /// <value>
-//    ///   <c>true</c> if multiple items can be selected; otherwise, <c>false</c>.
-//    /// </value>
-//    protected abstract bool Multiple { get; }
+    /// <summary>
+    /// Gets a value indicating whether the configuration allows multiple items to be selected.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if multiple items can be selected; otherwise, <c>false</c>.
+    /// </value>
+    protected abstract bool Multiple { get; }
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropDownReplaceDataTypeArtifactMigratorBase" /> class.
-//    /// </summary>
-//    /// <param name="fromEditorAlias">The editor alias to migrate from.</param>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    protected DropDownReplaceDataTypeArtifactMigratorBase(string fromEditorAlias, PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(fromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, propertyEditors, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownReplaceDataTypeArtifactMigratorBase" /> class.
+    /// </summary>
+    /// <param name="fromEditorAlias">The editor alias to migrate from.</param>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    protected DropDownReplaceDataTypeArtifactMigratorBase(string fromEditorAlias, PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(fromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override DropDownFlexibleConfiguration? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        var toConfiguration = new DropDownFlexibleConfiguration()
-//        {
-//            Multiple = Multiple
-//        };
+    /// <inheritdoc />
+    protected override DropDownFlexibleConfiguration? MigrateConfigurationObject(IDictionary<string, object> fromConfiguration)
+    {
+        var toConfiguration = new DropDownFlexibleConfiguration()
+        {
+            Multiple = Multiple
+        };
 
-//        foreach (var (key, value) in fromConfiguration)
-//        {
-//            if (key == "multiple")
-//            {
-//                toConfiguration.Multiple = TrueValue.Equals(value);
-//            }
-//            else if (int.TryParse(key, out var id) && value is not null)
-//            {
-//                toConfiguration.Items.Add(new ValueListConfiguration.ValueListItem()
-//                {
-//                    Id = id,
-//                    Value = value.ToString()
-//                });
-//            }
-//        }
+        foreach (var (key, value) in fromConfiguration)
+        {
+            if (key == "multiple")
+            {
+                toConfiguration.Multiple = TrueValue.Equals(value);
+            }
+            else if (int.TryParse(key, out _) && value?.ToString() is string itemValue)
+            {
+                toConfiguration.Items.Add(itemValue);
+            }
+        }
 
-//        return toConfiguration;
-//    }
+        return toConfiguration;
+    }
 
-//    /// <inheritdoc />
-//    protected override DropDownFlexibleConfiguration? GetDefaultConfiguration(IConfigurationEditor toConfigurationEditor)
-//    {
-//        var configuration = base.GetDefaultConfiguration(toConfigurationEditor);
-//        if (configuration is not null)
-//        {
-//            configuration.Multiple = Multiple;
-//        }
+    /// <inheritdoc />
+    protected override IDictionary<string, object> GetDefaultConfiguration(IConfigurationEditor toConfigurationEditor)
+    {
+        var configuration = base.GetDefaultConfiguration(toConfigurationEditor);
+        configuration["multiple"] = Multiple;
 
-//        return configuration;
-//    }
-//}
+        return configuration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropdownlistMultiplePublishKeysDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropdownlistMultiplePublishKeysDataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public class DropdownlistMultiplePublishKeysDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.DropdownlistMultiplePublishKeys";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public class DropdownlistMultiplePublishKeysDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropdownlistMultiplePublishKeys";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => true;
+    /// <inheritdoc />
+    protected override bool Multiple => true;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropdownlistMultiplePublishKeysDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public DropdownlistMultiplePublishKeysDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropdownlistMultiplePublishKeysDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public DropdownlistMultiplePublishKeysDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropdownlistPublishingKeysDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/DropdownlistPublishingKeysDataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
-///// </summary>
-//public class DropdownlistPublishingKeysDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.DropdownlistPublishingKeys";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> and the configuration from Umbraco 7 to <see cref="DropDownFlexibleConfiguration" />.
+/// </summary>
+public class DropdownlistPublishingKeysDataTypeArtifactMigrator : DropDownReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropdownlistPublishingKeys";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => false;
+    /// <inheritdoc />
+    protected override bool Multiple => false;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="DropdownlistPublishingKeysDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public DropdownlistPublishingKeysDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropdownlistPublishingKeysDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public DropdownlistPublishingKeysDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPicker2DataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPicker2DataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MediaPicker" /> and the configuration from Umbraco 7 to <see cref="MediaPickerConfiguration" />.
-///// </summary>
-//public class MediaPicker2DataTypeArtifactMigrator : MediaPickerReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.MediaPicker2";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MediaPicker3" /> and the configuration from Umbraco 7.
+/// </summary>
+public class MediaPicker2DataTypeArtifactMigrator : MediaPickerReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.MediaPicker2";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => false;
+    /// <inheritdoc />
+    protected override bool Multiple => false;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="MediaPicker2DataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public MediaPicker2DataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediaPicker2DataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public MediaPicker2DataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPickerDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPickerDataTypeArtifactMigrator.cs
@@ -1,35 +1,39 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to update the <see cref="Constants.PropertyEditors.Aliases.MediaPicker" /> editor configuration.
-///// </summary>
-//public class MediaPickerDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase
-//{
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="MediaPickerDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public MediaPickerDataTypeArtifactMigrator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(Constants.PropertyEditors.Aliases.MediaPicker, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to update the <see cref="EditorAlias" /> editor configuration.
+/// </summary>
+public class MediaPickerDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase
+{
+    private const string EditorAlias = "Umbraco.MediaPicker"; // TODO: Use DeployConstants.PropertyEditors.Legacy.Aliases.MediaPicker once made public
 
-//    /// <inheritdoc />
-//    protected override IDictionary<string, object?>? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        if (fromConfiguration.TryGetValue("startNodeId", out var startNodeIdValue) &&
-//            (startNodeIdValue?.ToString() is not string startNodeId || !UdiParser.TryParse(startNodeId, out _)))
-//        {
-//            // Remove invalid start node ID
-//            fromConfiguration.Remove("startNodeId");
-//        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediaPickerDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public MediaPickerDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(EditorAlias, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//        return fromConfiguration;
-//    }
-//}
+    /// <inheritdoc />
+    protected override IDictionary<string, object>? MigrateConfiguration(IDictionary<string, object> fromConfiguration)
+    {
+        if (fromConfiguration.TryGetValue("startNodeId", out var startNodeIdValue) &&
+            (startNodeIdValue?.ToString() is not string startNodeId || !UdiParser.TryParse(startNodeId, out _)))
+        {
+            // Remove invalid start node ID
+            fromConfiguration.Remove("startNodeId");
+        }
+
+        return fromConfiguration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPickerReplaceDataTypeArtifactMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MediaPickerReplaceDataTypeArtifactMigratorBase.cs
@@ -1,63 +1,60 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the editor alias with <see cref="Constants.PropertyEditors.Aliases.MediaPicker" /> and update the configuration.
-///// </summary>
-//public abstract class MediaPickerReplaceDataTypeArtifactMigratorBase : ReplaceDataTypeArtifactMigratorBase
-//{
-//    /// <summary>
-//    /// Gets a value indicating whether the configuration allows multiple items to be picked.
-//    /// </summary>
-//    /// <value>
-//    ///   <c>true</c> if multiple items can be picked; otherwise, <c>false</c>.
-//    /// </value>
-//    protected abstract bool Multiple { get; }
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the editor alias with <see cref="Constants.PropertyEditors.Aliases.MediaPicker3" /> and update the configuration.
+/// </summary>
+public abstract class MediaPickerReplaceDataTypeArtifactMigratorBase : ReplaceDataTypeArtifactMigratorBase
+{
+    /// <summary>
+    /// Gets a value indicating whether the configuration allows multiple items to be picked.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if multiple items can be picked; otherwise, <c>false</c>.
+    /// </value>
+    protected abstract bool Multiple { get; }
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="MediaPickerReplaceDataTypeArtifactMigratorBase" /> class.
-//    /// </summary>
-//    /// <param name="fromEditorAlias">From editor alias.</param>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    protected MediaPickerReplaceDataTypeArtifactMigratorBase(string fromEditorAlias, PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(fromEditorAlias, Constants.PropertyEditors.Aliases.MediaPicker, propertyEditors, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MediaPickerReplaceDataTypeArtifactMigratorBase" /> class.
+    /// </summary>
+    /// <param name="fromEditorAlias">From editor alias.</param>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    protected MediaPickerReplaceDataTypeArtifactMigratorBase(string fromEditorAlias, PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(fromEditorAlias, Constants.PropertyEditors.Aliases.MediaPicker3, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override IDictionary<string, object?>? MigrateConfiguration(IDictionary<string, object?> configuration)
-//    {
-//        if (!configuration.ContainsKey("multiPicker"))
-//        {
-//            configuration["multiPicker"] = Multiple;
-//        }
+    /// <inheritdoc />
+    protected override IDictionary<string, object>? MigrateConfiguration(IDictionary<string, object> configuration)
+    {
+        if (!configuration.ContainsKey("multiPicker"))
+        {
+            configuration["multiPicker"] = Multiple;
+        }
 
-//        if (configuration.TryGetValue("startNodeId", out var startNodeIdValue) &&
-//            (startNodeIdValue?.ToString() is not string startNodeId || !UdiParser.TryParse(startNodeId, out _)))
-//        {
-//            // Remove invalid start node ID
-//            configuration.Remove("startNodeId");
-//        }
+        if (configuration.TryGetValue("startNodeId", out var startNodeIdValue) &&
+            (startNodeIdValue?.ToString() is not string startNodeId || !UdiParser.TryParse(startNodeId, out _)))
+        {
+            // Remove invalid start node ID
+            configuration.Remove("startNodeId");
+        }
 
-//        return configuration;
-//    }
+        return configuration;
+    }
 
-//    /// <inheritdoc />
-//    protected override IDictionary<string, object?>? GetDefaultConfiguration(IConfigurationEditor toConfigurationEditor)
-//    {
-//        var configuration = base.GetDefaultConfiguration(toConfigurationEditor);
-//        if (configuration is not null)
-//        {
-//            configuration["multiPicker"] = Multiple;
-//        }
+    /// <inheritdoc />
+    protected override IDictionary<string, object> GetDefaultConfiguration(IConfigurationEditor toConfigurationEditor)
+    {
+        var configuration = base.GetDefaultConfiguration(toConfigurationEditor);
+        configuration["multiPicker"] = Multiple;
 
-//        return configuration;
-//    }
-//}
+        return configuration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MultipleMediaPickerDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/MultipleMediaPickerDataTypeArtifactMigrator.cs
@@ -1,26 +1,26 @@
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MediaPicker" /> and update the configuration.
-///// </summary>
-//public class MultipleMediaPickerDataTypeArtifactMigrator : MediaPickerReplaceDataTypeArtifactMigratorBase
-//{
-//    private const string FromEditorAlias = "Umbraco.MultipleMediaPicker";
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MediaPicker3" /> and update the configuration.
+/// </summary>
+public class MultipleMediaPickerDataTypeArtifactMigrator : MediaPickerReplaceDataTypeArtifactMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.MultipleMediaPicker";
 
-//    /// <inheritdoc />
-//    protected override bool Multiple => true;
+    /// <inheritdoc />
+    protected override bool Multiple => true;
 
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="MultipleMediaPickerDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="propertyEditors">The property editors.</param>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public MultipleMediaPickerDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
-//    { }
-//}
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultipleMediaPickerDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public MultipleMediaPickerDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(FromEditorAlias, propertyEditors, configurationEditorJsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RadioButtonListDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RadioButtonListDataTypeArtifactMigrator.cs
@@ -1,56 +1,49 @@
-//using System.Collections.Generic;
-//using Umbraco.Cms.Core;
-//using Umbraco.Cms.Core.Models;
-//using Umbraco.Cms.Core.PropertyEditors;
-//using Umbraco.Cms.Core.Semver;
-//using Umbraco.Cms.Core.Serialization;
-//using Umbraco.Deploy.Infrastructure.Artifacts;
-//using Umbraco.Deploy.Infrastructure.Migrators;
+using System.Collections.Generic;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
 
-//namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
-///// <summary>
-///// Migrates the <see cref="DataTypeArtifact" /> to replace the configuration of the <see cref="Constants.PropertyEditors.Aliases.RadioButtonList" /> editor from Umbraco 7 to <see cref="ValueListConfiguration" />.
-///// </summary>
-//public class RadioButtonListDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<ValueListConfiguration>
-//{
-//    /// <summary>
-//    /// Initializes a new instance of the <see cref="RadioButtonListDataTypeArtifactMigrator" /> class.
-//    /// </summary>
-//    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
-//    public RadioButtonListDataTypeArtifactMigrator(IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
-//        : base(Constants.PropertyEditors.Aliases.RadioButtonList, configurationEditorJsonSerializer)
-//        => MaxVersion = new SemVersion(3, 0, 0);
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the configuration of the <see cref="Constants.PropertyEditors.Aliases.RadioButtonList" /> editor from Umbraco 7 to <see cref="ValueListConfiguration" />.
+/// </summary>
+public class RadioButtonListDataTypeArtifactMigrator : DataTypeConfigurationArtifactMigratorBase<ValueListConfiguration>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RadioButtonListDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    public RadioButtonListDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.RadioButtonList, propertyEditors, configurationEditorJsonSerializer)
+        => MaxVersion = new SemVersion(3, 0, 0);
 
-//    /// <inheritdoc />
-//    protected override DataTypeArtifact? Migrate(DataTypeArtifact artifact)
-//    {
-//        artifact.DatabaseType = ValueStorageType.Nvarchar;
+    /// <inheritdoc />
+    protected override DataTypeArtifact? Migrate(DataTypeArtifact artifact)
+    {
+        artifact.DatabaseType = ValueStorageType.Nvarchar;
 
-//        return base.Migrate(artifact);
-//    }
+        return base.Migrate(artifact);
+    }
 
-//    /// <inheritdoc />
-//    protected override ValueListConfiguration? MigrateConfiguration(IDictionary<string, object?> fromConfiguration)
-//    {
-//        var toConfiguration = new ValueListConfiguration();
+    /// <inheritdoc />
+    protected override ValueListConfiguration? MigrateConfigurationObject(IDictionary<string, object> fromConfiguration)
+    {
+        var toConfiguration = new ValueListConfiguration();
 
-//        foreach (var (key, value) in fromConfiguration)
-//        {
-//            if (int.TryParse(key, out var id) && value is not null)
-//            {
-//                toConfiguration.Items.Add(new ValueListConfiguration.ValueListItem()
-//                {
-//                    Id = id,
-//                    Value = value.ToString()
-//                });
-//            }
-//        }
+        foreach (var (key, value) in fromConfiguration)
+        {
+            if (int.TryParse(key, out _) && value is string itemValue)
+            {
+                toConfiguration.Items.Add(itemValue);
+            }
+        }
 
-//        return toConfiguration;
-//    }
-
-//    /// <inheritdoc />
-//    protected override ValueListConfiguration? GetDefaultConfiguration()
-//        => new ValueListConfiguration();
-//}
+        return toConfiguration;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RelatedLinks2DataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RelatedLinks2DataTypeArtifactMigrator.cs
@@ -7,7 +7,7 @@ using Umbraco.Deploy.Infrastructure.Artifacts;
 namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
 /// <summary>
-/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MultiUrlPicker" /> and the configuration from Umbraco 7 to <see cref="MultiUrlPickerConfiguration" />.
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MultiUrlPicker" /> and the configuration from Umbraco 7.
 /// </summary>
 public class RelatedLinks2DataTypeArtifactMigrator : MultiUrlPickerReplaceDataTypeArtifactMigratorBase
 {

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RelatedLinksDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/RelatedLinksDataTypeArtifactMigrator.cs
@@ -7,7 +7,7 @@ using Umbraco.Deploy.Infrastructure.Artifacts;
 namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
 /// <summary>
-/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MultiUrlPicker" /> and the configuration from Umbraco 7 to <see cref="MultiUrlPickerConfiguration" />.
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.MultiUrlPicker" /> and the configuration from Umbraco 7.
 /// </summary>
 public class RelatedLinksDataTypeArtifactMigrator : MultiUrlPickerReplaceDataTypeArtifactMigratorBase
 {

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/TinyMCEv3DataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/DataType/TinyMCEv3DataTypeArtifactMigrator.cs
@@ -9,7 +9,7 @@ using Umbraco.Deploy.Infrastructure.Migrators;
 namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
 /// <summary>
-/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.TinyMce" />.
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the <see cref="FromEditorAlias" /> editor with <see cref="Constants.PropertyEditors.Aliases.RichText" />.
 /// </summary>
 public class TinyMCEv3DataTypeArtifactMigrator : ReplaceDataTypeArtifactMigratorBase
 {


### PR DESCRIPTION
PR https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/62 commented out some of the migrators that required a bit more work to rewrite (mainly due to updating Newtonsoft.Json to STJ and things being removed in v14).

This rewrites the existing migrators, but doing so highlighted additional changes that are required:
- Updating obsoleted editor alias `Umbraco.TinyMce` to `Umbraco.RichText`;
- Add `ReplaceMediaPickerDataTypeArtifactMigrator` by default (in Deploy), because the `Umbraco.MediaPicker` editor is removed.