### PR TITLE
Add migrators to support DocTypeGridEditor to Block Grid migration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,6 @@
   <!-- Umbraco packages -->
   <ItemGroup>
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="[13.0.0, 14)" />
-    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[13.1.0, 14)" />
+    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[13.2.0--rc1.preview.1.g294fdcd, 14)" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,6 @@
   <!-- Umbraco packages -->
   <ItemGroup>
     <PackageVersion Include="Umbraco.Cms.Web.Common" Version="[13.0.0, 14)" />
-    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[13.2.0--rc1.preview.1.g294fdcd, 14)" />
+    <PackageVersion Include="Umbraco.Deploy.Infrastructure" Version="[13.2.0-rc1, 14)" />
   </ItemGroup>
 </Project>

--- a/src/Umbraco.Deploy.Contrib/Migrators/DocTypeGridEditorPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/DocTypeGridEditorPropertyTypeMigrator.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Deploy.Infrastructure.Migrators;
+using Umbraco.Extensions;
+
+namespace Umbraco.Deploy.Contrib.Migrators;
+
+/// <summary>
+/// Migrates the property value when the editor of a property type changed from <see cref="Constants.PropertyEditors.Aliases.Grid" /> to <see cref="Constants.PropertyEditors.Aliases.BlockGrid" /> and supports DocTypeGridEditor.
+/// </summary>
+public class DocTypeGridEditorPropertyTypeMigrator : GridPropertyTypeMigrator
+{
+    private readonly IJsonSerializer _jsonSerializer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DocTypeGridEditorPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="logger">The logger.</param>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    /// <param name="dataTypeService">The data type service.</param>
+    /// <param name="shortStringHelper">The short string helper.</param>
+    /// <param name="contentTypeService">The content type service.</param>
+    /// <param name="mediaService">The media service.</param>
+    public DocTypeGridEditorPropertyTypeMigrator(ILogger<GridPropertyTypeMigrator> logger, IJsonSerializer jsonSerializer, IDataTypeService dataTypeService, IShortStringHelper shortStringHelper, IContentTypeService contentTypeService, IMediaService mediaService)
+        : base(logger, jsonSerializer, dataTypeService, shortStringHelper, contentTypeService, mediaService)
+        => _jsonSerializer = jsonSerializer;
+
+    /// <inheritdoc />
+    protected override BlockItemData? MigrateGridControl(GridValue.GridControl gridControl, BlockGridConfiguration configuration, IContextCache contextCache)
+    {
+        if (TryDeserialize(gridControl.Value, out DocTypeGridEditorValue? value))
+        {
+            return MigrateGridControl(value, configuration, contextCache);
+        }
+
+        return base.MigrateGridControl(gridControl, configuration, contextCache);
+    }
+
+    /// <summary>
+    /// Migrates the grid control.
+    /// </summary>
+    /// <param name="value">The DTGE value.</param>
+    /// <param name="configuration">The configuration.</param>
+    /// <param name="contextCache">The context cache.</param>
+    /// <returns>
+    /// The block item data, or <c>null</c> if migration should be skipped.
+    /// </returns>
+    protected virtual BlockItemData? MigrateGridControl(DocTypeGridEditorValue value, BlockGridConfiguration configuration, IContextCache contextCache)
+    {
+        IContentType contentType = GetContentType(value.ContentTypeAlias, configuration, contextCache)
+            ?? throw new InvalidOperationException($"Migrating legacy grid failed, because content type with alias '{value.ContentTypeAlias}' could not be found (in the Block Grid configuration).");
+
+        return new BlockItemData()
+        {
+            Udi = Udi.Create(Constants.UdiEntityType.Element, value.Id),
+            ContentTypeKey = contentType.Key,
+            RawPropertyValues = value.Value
+        };
+    }
+
+    private bool TryDeserialize(JToken? value, [NotNullWhen(true)] out DocTypeGridEditorValue? docTypeGridEditorValue)
+    {
+        try
+        {
+            docTypeGridEditorValue = value switch
+            {
+                JObject jsonObject => jsonObject.ToObject<DocTypeGridEditorValue>(),
+                JToken jsonToken when jsonToken.Value<string>() is string json && json.DetectIsJson() => _jsonSerializer.Deserialize<DocTypeGridEditorValue>(json),
+                _ => null
+            };
+
+            return !string.IsNullOrEmpty(docTypeGridEditorValue?.ContentTypeAlias);
+        }
+        catch (JsonSerializationException)
+        {
+            docTypeGridEditorValue = null;
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// The DTGE grid editor value.
+    /// </summary>
+    protected sealed class DocTypeGridEditorValue
+    {
+        /// <summary>
+        /// Gets or sets the value.
+        /// </summary>
+        /// <value>
+        /// The value.
+        /// </value>
+        [JsonProperty("value")]
+        public Dictionary<string, object?> Value { get; set; } = new();
+
+        /// <summary>
+        /// Gets or sets the content type alias.
+        /// </summary>
+        /// <value>
+        /// The content type alias.
+        /// </value>
+        [JsonProperty("dtgeContentTypeAlias")]
+        public string ContentTypeAlias { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
+        [JsonProperty("id")]
+        public Guid Id { get; set; } = Guid.NewGuid();
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/ReplaceDocTypeGridEditorDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/ReplaceDocTypeGridEditorDataTypeArtifactMigrator.cs
@@ -59,20 +59,25 @@ public class ReplaceDocTypeGridEditorDataTypeArtifactMigrator : ReplaceGridDataT
 
         // Migrate DTGE editors
         var allElementTypes = GetAllElementTypes().ToList();
+        var migratedContentTypeKeys = new HashSet<Guid>();
         foreach (IGridEditorConfig gridEditor in GetGridEditors(gridLayouts).Where(IsDocTypeGridEditor))
         {
             foreach (Guid contentElementTypeKey in MigrateDocTypeGridEditor(gridEditor, allElementTypes))
             {
-                yield return (gridEditor.Alias, new BlockGridBlockConfiguration()
+                // Avoid DocTypeGridEditors returning duplicate block configurations for the same content element type
+                if (migratedContentTypeKeys.Add(contentElementTypeKey))
                 {
-                    ContentElementTypeKey = contentElementTypeKey,
-                    Label = gridEditor.Config.TryGetValue("nameTemplate", out var nameTemplateConfig) && nameTemplateConfig is string nameTemplate && !string.IsNullOrEmpty(nameTemplate)
+                    yield return (gridEditor.Alias, new BlockGridBlockConfiguration()
+                    {
+                        ContentElementTypeKey = contentElementTypeKey,
+                        Label = gridEditor.Config.TryGetValue("nameTemplate", out var nameTemplateConfig) && nameTemplateConfig is string nameTemplate && !string.IsNullOrEmpty(nameTemplate)
                         ? nameTemplate
                         : gridEditor.NameTemplate,
-                    EditorSize = gridEditor.Config.TryGetValue("overlaySize", out var overviewSizeConfig) && overviewSizeConfig is string overviewSize && !string.IsNullOrEmpty(overviewSize)
+                        EditorSize = gridEditor.Config.TryGetValue("overlaySize", out var overviewSizeConfig) && overviewSizeConfig is string overviewSize && !string.IsNullOrEmpty(overviewSize)
                         ? overviewSize
                         : null,
-                });
+                    });
+                }
             }
         }
     }

--- a/src/Umbraco.Deploy.Contrib/Migrators/ReplaceDocTypeGridEditorDataTypeArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/ReplaceDocTypeGridEditorDataTypeArtifactMigrator.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Configuration.Grid;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.PropertyEditors;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Cms.Core.Services;
+using Umbraco.Cms.Core.Strings;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Migrators;
+using Umbraco.Extensions;
+using static Umbraco.Cms.Core.PropertyEditors.BlockGridConfiguration;
+
+namespace Umbraco.Deploy.Contrib.Migrators;
+
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to replace the legacy/obsoleted <see cref="Constants.PropertyEditors.Aliases.Grid" /> editor with <see cref="Constants.PropertyEditors.Aliases.BlockGrid" /> and support DTGE grid editors.
+/// </summary>
+public class ReplaceDocTypeGridEditorDataTypeArtifactMigrator : ReplaceGridDataTypeArtifactMigrator
+{
+    private readonly IContentTypeService _contentTypeService;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to add the default DTGE grid editor (if not configured in the grid.editors.config.js files).
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if the default DTGE grid editor is added; otherwise, <c>false</c>.
+    /// </value>
+    /// <remarks>
+    /// Defaults to <c>true</c>.
+    /// </remarks>
+    protected bool AddDefaultDocTypeGridEditor { get; init; } = true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceDocTypeGridEditorDataTypeArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="propertyEditors">The property editors.</param>
+    /// <param name="configurationEditorJsonSerializer">The configuration editor JSON serializer.</param>
+    /// <param name="contentTypeService">The content type service.</param>
+    /// <param name="dataTypeService">The data type service.</param>
+    /// <param name="shortStringHelper">The short string helper.</param>
+    /// <param name="gridConfig">The grid configuration.</param>
+    public ReplaceDocTypeGridEditorDataTypeArtifactMigrator(PropertyEditorCollection propertyEditors, IConfigurationEditorJsonSerializer configurationEditorJsonSerializer, IContentTypeService contentTypeService, IDataTypeService dataTypeService, IShortStringHelper shortStringHelper, IGridConfig gridConfig)
+        : base(propertyEditors, configurationEditorJsonSerializer, contentTypeService, dataTypeService, shortStringHelper, gridConfig)
+        => _contentTypeService = contentTypeService;
+
+    /// <inheritdoc />
+    protected override IEnumerable<(string, BlockGridBlockConfiguration)> MigrateGridEditors(IEnumerable<GridConfigurationLayout> gridLayouts)
+    {
+        // Migrate regular grid editors (DTGE editors are skipped)
+        foreach ((string alias, BlockGridBlockConfiguration blockGridBlockConfiguration) in base.MigrateGridEditors(gridLayouts))
+        {
+            yield return (alias, blockGridBlockConfiguration);
+        }
+
+        // Migrate DTGE editors
+        var allElementTypes = GetAllElementTypes().ToList();
+        foreach (IGridEditorConfig gridEditor in GetGridEditors(gridLayouts).Where(IsDocTypeGridEditor))
+        {
+            foreach (Guid contentElementTypeKey in MigrateDocTypeGridEditor(gridEditor, allElementTypes))
+            {
+                yield return (gridEditor.Alias, new BlockGridBlockConfiguration()
+                {
+                    ContentElementTypeKey = contentElementTypeKey,
+                    Label = gridEditor.Config.TryGetValue("nameTemplate", out var nameTemplateConfig) && nameTemplateConfig is string nameTemplate && !string.IsNullOrEmpty(nameTemplate)
+                        ? nameTemplate
+                        : gridEditor.NameTemplate,
+                    EditorSize = gridEditor.Config.TryGetValue("overlaySize", out var overviewSizeConfig) && overviewSizeConfig is string overviewSize && !string.IsNullOrEmpty(overviewSize)
+                        ? overviewSize
+                        : null,
+                });
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override IEnumerable<IGridEditorConfig> GetGridEditors()
+    {
+        foreach (IGridEditorConfig gridEditor in base.GetGridEditors())
+        {
+            yield return gridEditor;
+        }
+
+        if (AddDefaultDocTypeGridEditor)
+        {
+            yield return new GridEditor()
+            {
+                Name = "Doc Type",
+                Alias = "docType",
+                View = "/App_Plugins/DocTypeGridEditor/Views/doctypegrideditor.html",
+                Render = "/App_Plugins/DocTypeGridEditor/Render/DocTypeGridEditor.cshtml",
+                Icon = "icon-item-arrangement",
+            };
+        }
+    }
+
+    /// <inheritdoc />
+    protected override Guid? MigrateGridEditor(IGridEditorConfig gridEditor)
+        // Skip migrating DocTypeGridEditor using base implementation (as that creates a new element type)
+        => IsDocTypeGridEditor(gridEditor) is false ? base.MigrateGridEditor(gridEditor) : null;
+
+    /// <summary>
+    /// Migrates the DocTypeGridEditor.
+    /// </summary>
+    /// <param name="gridEditor">The grid editor.</param>
+    /// <param name="allElementTypes">All element types.</param>
+    /// <returns>
+    /// The keys of the content element types of the migrated grid editor.
+    /// </returns>
+    protected virtual IEnumerable<Guid> MigrateDocTypeGridEditor(IGridEditorConfig gridEditor, IEnumerable<IContentType> allElementTypes)
+    {
+        if (gridEditor.Config.TryGetValue("allowedDocTypes", out var allowedDocTypesConfig) &&
+            allowedDocTypesConfig is JArray allowedDocTypes &&
+            allowedDocTypes.Values<string>().WhereNotNull().ToArray() is string[] docTypes &&
+            docTypes.Length > 0)
+        {
+            // Use regex matching
+            return allElementTypes.Where(x => docTypes.Any(y => Regex.IsMatch(x.Alias, y))).Select(x => x.Key);
+        }
+
+        // Return all
+        return allElementTypes.Select(x => x.Key);
+    }
+
+    /// <summary>
+    /// Gets all element types.
+    /// </summary>
+    /// <returns>
+    /// Returns all element types.
+    /// </returns>
+    /// <remarks>
+    /// The default implementation excludes element types with aliases that start with <c>gridLayout_</c>, <c>gridRow_</c>, <c>gridEditor_</c> or <c>gridSettings_</c>.
+    /// </remarks>
+    protected virtual IEnumerable<IContentType> GetAllElementTypes()
+    {
+        static bool IsAllowedElementType(string alias) => !alias.StartsWith("gridLayout_") && !alias.StartsWith("gridRow_") && !alias.StartsWith("gridEditor_") && !alias.StartsWith("gridSettings_");
+
+        return _contentTypeService.GetAllElementTypes().Where(x => IsAllowedElementType(x.Alias));
+    }
+
+    /// <summary>
+    /// Determines whether the grid editor is the DocTypeGridEditor.
+    /// </summary>
+    /// <param name="gridEditor">The grid editor.</param>
+    /// <returns>
+    ///   <c>true</c> if the grid editor is the DocTypeGridEditor; otherwise, <c>false</c>.
+    /// </returns>
+    protected static bool IsDocTypeGridEditor(IGridEditorConfig gridEditor)
+        => gridEditor.View?.Contains("doctypegrideditor", StringComparison.OrdinalIgnoreCase) is true;
+}

--- a/src/Umbraco.Deploy.Contrib/packages.lock.json
+++ b/src/Umbraco.Deploy.Contrib/packages.lock.json
@@ -49,12 +49,12 @@
       },
       "Umbraco.Deploy.Infrastructure": {
         "type": "Direct",
-        "requested": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)",
-        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
-        "contentHash": "7KpMTPrF7XjSq+xfbvxbcEzvkHxGbR/K5tW/fNcenljEJpjZW2/8k+vsuYxvLxHr48o6efLv2RSbUb4MtAz+mw==",
+        "requested": "[13.2.0-rc1, 14.0.0)",
+        "resolved": "13.2.0-rc1",
+        "contentHash": "VhVsKrkpxreisA4JWVD9HnPsjaYckHZbA4ED+OSVlwa9AmwNRXAsoRtaZqaEDuxMY3fzZxZRpihBFzIIDxuosg==",
         "dependencies": {
-          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0-0)",
-          "Umbraco.Deploy.Core": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0-0)"
+          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0)",
+          "Umbraco.Deploy.Core": "[13.2.0-rc1, 14.0.0)"
         }
       },
       "Umbraco.GitVersioning.Extensions": {
@@ -2243,10 +2243,10 @@
       },
       "Umbraco.Deploy.Core": {
         "type": "Transitive",
-        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
-        "contentHash": "yXF5WWHRcDg+TiTupStw6yrzSJMbsgPE/TGT1CtPLGFEI/hkQS1JRXVyeqEiRTVKXrxbGU0hUJeOuUEeXkxsEA==",
+        "resolved": "13.2.0-rc1",
+        "contentHash": "y9dkLU297uLGhzRB1A32DjFbMZoySM4TtcC/Jq2gvJw4uds3S5T0pfXgI+lBGaEbg/oRPtAr+0OHXugVYXM1Ag==",
         "dependencies": {
-          "Umbraco.Cms.Core": "[13.0.0, 14.0.0-0)"
+          "Umbraco.Cms.Core": "[13.0.0, 14.0.0)"
         }
       }
     }

--- a/src/Umbraco.Deploy.Contrib/packages.lock.json
+++ b/src/Umbraco.Deploy.Contrib/packages.lock.json
@@ -49,12 +49,12 @@
       },
       "Umbraco.Deploy.Infrastructure": {
         "type": "Direct",
-        "requested": "[13.1.0, 14.0.0)",
-        "resolved": "13.1.0",
-        "contentHash": "LS2RJC4znoS4FvZEuDD0Fw8tdOhP0nAf4HYoCRirPNfaP4GOt5/jjTxr6TyF6nJr2JPXr9qEE40DoOC5+uXMLg==",
+        "requested": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)",
+        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
+        "contentHash": "7KpMTPrF7XjSq+xfbvxbcEzvkHxGbR/K5tW/fNcenljEJpjZW2/8k+vsuYxvLxHr48o6efLv2RSbUb4MtAz+mw==",
         "dependencies": {
-          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0)",
-          "Umbraco.Deploy.Core": "[13.1.0, 14.0.0)"
+          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0-0)",
+          "Umbraco.Deploy.Core": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0-0)"
         }
       },
       "Umbraco.GitVersioning.Extensions": {
@@ -2243,10 +2243,10 @@
       },
       "Umbraco.Deploy.Core": {
         "type": "Transitive",
-        "resolved": "13.1.0",
-        "contentHash": "UnXxci5sanYHLTABTjUdYLkKuRaoQPYS9lp/nZ1r8h+OcDo/h4gES6VnS1OFE8XAZRanae9IqyT1TtMTReNUoQ==",
+        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
+        "contentHash": "yXF5WWHRcDg+TiTupStw6yrzSJMbsgPE/TGT1CtPLGFEI/hkQS1JRXVyeqEiRTVKXrxbGU0hUJeOuUEeXkxsEA==",
         "dependencies": {
-          "Umbraco.Cms.Core": "[13.0.0, 14.0.0)"
+          "Umbraco.Cms.Core": "[13.0.0, 14.0.0-0)"
         }
       }
     }

--- a/tests/Umbraco.Deploy.Contrib.Tests/packages.lock.json
+++ b/tests/Umbraco.Deploy.Contrib.Tests/packages.lock.json
@@ -57,12 +57,12 @@
       },
       "Umbraco.Deploy.Infrastructure": {
         "type": "Direct",
-        "requested": "[13.1.0, 14.0.0)",
-        "resolved": "13.1.0",
-        "contentHash": "LS2RJC4znoS4FvZEuDD0Fw8tdOhP0nAf4HYoCRirPNfaP4GOt5/jjTxr6TyF6nJr2JPXr9qEE40DoOC5+uXMLg==",
+        "requested": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)",
+        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
+        "contentHash": "7KpMTPrF7XjSq+xfbvxbcEzvkHxGbR/K5tW/fNcenljEJpjZW2/8k+vsuYxvLxHr48o6efLv2RSbUb4MtAz+mw==",
         "dependencies": {
-          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0)",
-          "Umbraco.Deploy.Core": "[13.1.0, 14.0.0)"
+          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0-0)",
+          "Umbraco.Deploy.Core": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0-0)"
         }
       },
       "Umbraco.GitVersioning.Extensions": {
@@ -2749,17 +2749,17 @@
       },
       "Umbraco.Deploy.Core": {
         "type": "Transitive",
-        "resolved": "13.1.0",
-        "contentHash": "UnXxci5sanYHLTABTjUdYLkKuRaoQPYS9lp/nZ1r8h+OcDo/h4gES6VnS1OFE8XAZRanae9IqyT1TtMTReNUoQ==",
+        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
+        "contentHash": "yXF5WWHRcDg+TiTupStw6yrzSJMbsgPE/TGT1CtPLGFEI/hkQS1JRXVyeqEiRTVKXrxbGU0hUJeOuUEeXkxsEA==",
         "dependencies": {
-          "Umbraco.Cms.Core": "[13.0.0, 14.0.0)"
+          "Umbraco.Cms.Core": "[13.0.0, 14.0.0-0)"
         }
       },
       "umbraco.deploy.contrib": {
         "type": "Project",
         "dependencies": {
           "Umbraco.Cms.Web.Common": "[13.0.0, 14.0.0)",
-          "Umbraco.Deploy.Infrastructure": "[13.1.0, 14.0.0)"
+          "Umbraco.Deploy.Infrastructure": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)"
         }
       },
       "Moq": {

--- a/tests/Umbraco.Deploy.Contrib.Tests/packages.lock.json
+++ b/tests/Umbraco.Deploy.Contrib.Tests/packages.lock.json
@@ -57,12 +57,12 @@
       },
       "Umbraco.Deploy.Infrastructure": {
         "type": "Direct",
-        "requested": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)",
-        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
-        "contentHash": "7KpMTPrF7XjSq+xfbvxbcEzvkHxGbR/K5tW/fNcenljEJpjZW2/8k+vsuYxvLxHr48o6efLv2RSbUb4MtAz+mw==",
+        "requested": "[13.2.0-rc1, 14.0.0)",
+        "resolved": "13.2.0-rc1",
+        "contentHash": "VhVsKrkpxreisA4JWVD9HnPsjaYckHZbA4ED+OSVlwa9AmwNRXAsoRtaZqaEDuxMY3fzZxZRpihBFzIIDxuosg==",
         "dependencies": {
-          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0-0)",
-          "Umbraco.Deploy.Core": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0-0)"
+          "Umbraco.Cms.Web.BackOffice": "[13.0.0, 14.0.0)",
+          "Umbraco.Deploy.Core": "[13.2.0-rc1, 14.0.0)"
         }
       },
       "Umbraco.GitVersioning.Extensions": {
@@ -2749,17 +2749,17 @@
       },
       "Umbraco.Deploy.Core": {
         "type": "Transitive",
-        "resolved": "13.2.0--rc1.preview.1.g294fdcd",
-        "contentHash": "yXF5WWHRcDg+TiTupStw6yrzSJMbsgPE/TGT1CtPLGFEI/hkQS1JRXVyeqEiRTVKXrxbGU0hUJeOuUEeXkxsEA==",
+        "resolved": "13.2.0-rc1",
+        "contentHash": "y9dkLU297uLGhzRB1A32DjFbMZoySM4TtcC/Jq2gvJw4uds3S5T0pfXgI+lBGaEbg/oRPtAr+0OHXugVYXM1Ag==",
         "dependencies": {
-          "Umbraco.Cms.Core": "[13.0.0, 14.0.0-0)"
+          "Umbraco.Cms.Core": "[13.0.0, 14.0.0)"
         }
       },
       "umbraco.deploy.contrib": {
         "type": "Project",
         "dependencies": {
           "Umbraco.Cms.Web.Common": "[13.0.0, 14.0.0)",
-          "Umbraco.Deploy.Infrastructure": "[13.2.0--rc1.preview.1.g294fdcd, 14.0.0)"
+          "Umbraco.Deploy.Infrastructure": "[13.2.0-rc1, 14.0.0)"
         }
       },
       "Moq": {


### PR DESCRIPTION
This PR extends the built-in migrators (coming in Deploy 13.2.0) to migrate the legacy Grid layout using DocTypeGridEditor (exports need to be created using a version that contains PR https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/65):
- `ReplaceDocTypeGridEditorDataTypeArtifactMigrator` extends `ReplaceGridDataTypeArtifactMigrator` and ensures any DocTypeGridEditor is migrated to blocks using the allowed element types (otherwise they will be migrated to new element types by the default implementation);
- `DocTypeGridEditorPropertyTypeMigrator` extends `GridPropertyTypeMigrator` and ensures the DocTypeGridEditor values are mapped 1:1 to the block item data.

I've created a Deploy 13.2.0-rc1 preview version on the MyGet pre-releases feed to test (and ensure this PR builds). Testing by HQ is easier done by copying these files into the latest v13 Deploy codebase.

The migrations can to be added using the following composer:

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Deploy.Infrastructure.Migrators;

internal sealed class DeployMigratorsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactMigrators()
            .Append<ReplaceNestedContentDataTypeArtifactMigrator>()
            .Append<ReplaceDocTypeGridEditorDataTypeArtifactMigrator>()
            .Append<ReplaceUnknownEditorDataTypeArtifactMigrator>();

        builder.DeployPropertyTypeMigrators()
            .Append<NestedContentPropertyTypeMigrator>()
            .Append<DocTypeGridEditorPropertyTypeMigrator>();
    }
}
```


And to test, I've exported a v8 site using The Starter Kit and DocTypeGridEditor (used on the Biker Jacket product page): [export-TheStarterKit-DocTypeGridEditor.zip](https://github.com/user-attachments/files/16131641/export-TheStarterKit-DocTypeGridEditor.zip).