### PR TITLE
Add Matryoshka Group Separator artifact migrator

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Migrators/ReplaceMatryoshkaArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/ReplaceMatryoshkaArtifactMigrator.cs
@@ -1,0 +1,100 @@
+using System.Linq;
+using System;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Deploy.Core.Migrators;
+using Umbraco.Deploy.Infrastructure.Artifacts;
+using Umbraco.Deploy.Infrastructure.Artifacts.ContentType;
+using System.Collections.Generic;
+using Umbraco.Extensions;
+
+namespace Umbraco.Deploy.Contrib.Migrators;
+
+/// <summary>
+/// Migrates the <see cref="DataTypeArtifact" /> to remove Matryoshka data types (using the <see cref="EditorAlias" /> editor) and
+/// <see cref="ContentTypeArtifactBase" /> to replace properties using the removed Matryoshka data types with native groups.
+/// </summary>
+public sealed class ReplaceMatryoshkaArtifactMigrator : ArtifactMigratorBase<IArtifact>
+{
+    private const string EditorAlias = "Our.Umbraco.Matryoshka.GroupSeparator";
+
+    private readonly HashSet<Guid> _removedDataTypeKeys = [];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ReplaceMatryoshkaArtifactMigrator" /> class.
+    /// </summary>
+    public ReplaceMatryoshkaArtifactMigrator()
+        // Matryoshka was only supported on v8
+        => MaxVersion = new SemVersion(9, 0, 0);
+
+    /// <inheritdoc />
+    protected override bool CanMigrateType(Type type)
+        => type == typeof(DataTypeArtifact) || type.Inherits<ContentTypeArtifactBase>();
+
+    /// <inheritdoc />
+    protected override IArtifact? Migrate(IArtifact artifact)
+        => artifact switch
+        {
+            // Remove Matryoshka data types
+            DataTypeArtifact dataTypeArtifact when dataTypeArtifact.EditorAlias == EditorAlias => Migrate(dataTypeArtifact),
+            // Replace properties with removed Matryoshka data types with native groups
+            ContentTypeArtifactBase contentTypeArtifactBase => Migrate(contentTypeArtifactBase),
+            // Ignore other artifacts
+            _ => artifact,
+        };
+
+    private DataTypeArtifact? Migrate(DataTypeArtifact artifact)
+    {
+        // Track removed data types by key
+        _removedDataTypeKeys.Add(artifact.Key);
+
+        return null;
+    }
+
+    private ContentTypeArtifactBase? Migrate(ContentTypeArtifactBase artifact)
+    {
+        // Remove property types using the removed data types
+        artifact.PropertyTypes = artifact.PropertyTypes.Where(x => _removedDataTypeKeys.Contains(x.DataType.Guid) is false).ToArray();
+
+        // Convert property groups to tabs and create new groups when removed data types are found
+        var propertyGroups = new List<ContentTypeArtifactBase.PropertyGroup>();
+        foreach (var propertyGroup in artifact.PropertyGroups.OrderBy(x => x.SortOrder).ToArray())
+        {
+            // Convert groups to tabs
+            propertyGroup.Type = (short)PropertyGroupType.Tab;
+
+            var propertyTypes = new List<ContentTypeArtifactBase.PropertyType>();
+            foreach (var propertyType in propertyGroup.PropertyTypes.OrderByDescending(x => x.SortOrder).ToArray())
+            {
+                if (_removedDataTypeKeys.Contains(propertyType.DataType.Guid))
+                {
+                    // Create new group below tab
+                    propertyGroups.Add(new ContentTypeArtifactBase.PropertyGroup()
+                    {
+                        Key = propertyType.Key,
+                        Name = propertyType.Name,
+                        Alias = propertyGroup.Alias + "/" + propertyType.Alias,
+                        PropertyTypes = propertyTypes.ToArray(),
+                        SortOrder = propertyType.SortOrder,
+                        Type = (short)PropertyGroupType.Group,
+                    });
+
+                    propertyTypes.Clear();
+                }
+                else
+                {
+                    // Keep property type
+                    propertyTypes.Add(propertyType);
+                }
+            }
+
+            propertyGroup.PropertyTypes = propertyTypes.ToArray();
+            propertyGroups.Add(propertyGroup);
+        }
+
+        artifact.PropertyGroups = propertyGroups.ToArray();
+
+        return artifact;
+    }
+}


### PR DESCRIPTION
This adds support for migrating Matryoshka Group Separators into native property groups by removing the Matryoshka data types during import and migrating the document, media and member types. Native property groups are also changed into tabs, similarly to how they were displayed with Matryoshka installed.

To test, add the following composer to a v13 project (it's probably the easiest to copy over the file in this PR into the Deploy test site) and import [export-TheStarterKit-Matryoshka.zip](https://github.com/user-attachments/files/16143567/export-TheStarterKit-Matryoshka.zip):

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Deploy.Infrastructure.Migrators;

internal sealed class DeployMigratorsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactMigrators()
            .Append<ReplaceMatryoshkaArtifactMigrator>()
            .Append<ReplaceUnknownEditorDataTypeArtifactMigrator>();
    }
}
```

-------------

<details>
<summary>Screenshots of before and after migration</summary>

This v8 export contains The Starter Kit with an updated Home document type that uses Matryoshka:

![Home document type](https://github.com/umbraco/Umbraco.Deploy.Contrib/assets/1051287/79dcd904-b6d6-40c3-87da-f340511292bd)

Which is displayed as:

![Home content](https://github.com/umbraco/Umbraco.Deploy.Contrib/assets/1051287/df55420d-d607-4c69-99d8-041656ea3e71)

After importing/migrating, the document type contains native tabs and groups using the same names as the Matryoshka Group Separators:

![Migrated document type](https://github.com/umbraco/Umbraco.Deploy.Contrib/assets/1051287/f40f6d4d-b4cf-4970-9aab-4a1f574782a7)

</details>