### PR TITLE
Migrate nested/recursive legacy pre-value property values

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
@@ -26,8 +26,8 @@ public static class ArtifactMigratorCollectionBuilderExtensions
             .Append<ContentPicker2DataTypeArtifactMigrator>()
             .Append<ContentPickerAliasDataTypeArtifactMigrator>()
             .Append<DateDataTypeArtifactMigrator>()
+            .Append<DropDownFlexibleDataTypeArtifactMigrator>() // Ensure this is appended before other dropdown migrators to avoid duplicate migration
             .Append<DropDownDataTypeArtifactMigrator>()
-            .Append<DropDownFlexibleDataTypeArtifactMigrator>()
             .Append<DropdownlistMultiplePublishKeysDataTypeArtifactMigrator>()
             .Append<DropdownlistPublishingKeysDataTypeArtifactMigrator>()
             .Append<DropDownMultipleDataTypeArtifactMigrator>()

--- a/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
@@ -44,8 +44,6 @@ public static class ArtifactMigratorCollectionBuilderExtensions
             .Append<TextboxDataTypeArtifactMigrator>()
             .Append<TextboxMultipleDataTypeArtifactMigrator>()
             .Append<TinyMCEv3DataTypeArtifactMigrator>()
-            // Property values
-            .Append<CheckBoxListPropertyValueArtifactMigrator>()
-            .Append<DropDownListFlexiblePropertyValueArtifactMigrator>()
-            .Append<RadioButtonListPropertyValueArtifactMigrator>();
+            // Add prefixes to pre-value property editor aliases, triggering property type migrators
+            .Append<PrevalueArtifactMigrator>();
 }

--- a/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
@@ -15,6 +15,10 @@ public static class PropertyTypeMigratorCollectionBuilderExtensions
         => propertyTypeMigratorCollectionBuilder
             // Pre-values to a single value or JSON array
             .Append<CheckBoxListPropertyTypeMigrator>()
+            .Append<DropDownPropertyTypeMigrator>()
             .Append<DropDownListFlexiblePropertyTypeMigrator>()
+            .Append<DropdownlistMultiplePublishKeysPropertyTypeMigrator>()
+            .Append<DropdownlistPublishingKeysPropertyTypeMigrator>()
+            .Append<DropDownMultiplePropertyTypeMigrator>()
             .Append<RadioButtonListPropertyTypeMigrator>();
 }

--- a/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
@@ -1,0 +1,20 @@
+using Umbraco.Deploy.Contrib.Migrators.Legacy;
+using Umbraco.Deploy.Core.Migrators;
+
+namespace Umbraco.Extensions;
+
+public static class PropertyTypeMigratorCollectionBuilderExtensions
+{
+    /// <summary>
+    /// Adds the legacy property type migrators to allow importing from Umbraco 7.
+    /// </summary>
+    /// <returns>
+    /// The property type migrator collection builder.
+    /// </returns>
+    public static PropertyTypeMigratorCollectionBuilder AddLegacyMigrators(this PropertyTypeMigratorCollectionBuilder propertyTypeMigratorCollectionBuilder)
+        => propertyTypeMigratorCollectionBuilder
+            // Pre-values to a single value or JSON array
+            .Append<CheckBoxListPropertyTypeMigrator>()
+            .Append<DropDownListFlexiblePropertyTypeMigrator>()
+            .Append<RadioButtonListPropertyTypeMigrator>();
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/CheckBoxListPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/CheckBoxListPropertyTypeMigrator.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value using the <see cref="Constants.PropertyEditors.Aliases.CheckBoxList" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class CheckBoxListPropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckBoxListPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public CheckBoxListPropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.CheckBoxList, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/CheckBoxListPropertyValueArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/CheckBoxListPropertyValueArtifactMigrator.cs
@@ -1,3 +1,4 @@
+using System;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -9,6 +10,7 @@ namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 /// <summary>
 /// Migrates the <see cref="PropertyValueWithSegments" /> using the <see cref="Constants.PropertyEditors.Aliases.CheckBoxList" /> editor from the <see cref="ContentArtifactBase" /> containing prevalues (seperated by <see cref="PrevaluePropertyValueArtifactMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
 /// </summary>
+[Obsolete("Migrating property values in an artifact migrator does not support nested/recursive properties. Use the PrevalueArtifactMigrator and CheckBoxListPropertyTypeMigrator instead. This class will be removed in a future version.")]
 public class CheckBoxListPropertyValueArtifactMigrator : PrevaluePropertyValueArtifactMigratorBase
 {
     /// <inheritdoc />

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownListFlexiblePropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownListFlexiblePropertyTypeMigrator.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value using the <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class DropDownListFlexiblePropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownListFlexiblePropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public DropDownListFlexiblePropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.DropDownListFlexible, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownListFlexiblePropertyValueArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownListFlexiblePropertyValueArtifactMigrator.cs
@@ -1,3 +1,4 @@
+using System;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -9,6 +10,7 @@ namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 /// <summary>
 /// Migrates the <see cref="PropertyValueWithSegments" /> using the <see cref="Constants.PropertyEditors.Aliases.DropDownListFlexible" /> editor from the <see cref="ContentArtifactBase" /> containing prevalues (seperated by <see cref="PrevaluePropertyValueArtifactMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
 /// </summary>
+[Obsolete("Migrating property values in an artifact migrator does not support nested/recursive properties. Use the PrevalueArtifactMigrator and DropDownListFlexiblePropertyTypeMigrator instead. This class will be removed in a future version.")]
 public class DropDownListFlexiblePropertyValueArtifactMigrator : PrevaluePropertyValueArtifactMigratorBase
 {
     /// <inheritdoc />

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownMultiplePropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownMultiplePropertyTypeMigrator.cs
@@ -1,0 +1,23 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value from the legacy <see cref="FromEditorAlias" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class DropDownMultiplePropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropDownMultiple";
+
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownMultiplePropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public DropDownMultiplePropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropDownPropertyTypeMigrator.cs
@@ -1,0 +1,23 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value from the legacy <see cref="FromEditorAlias" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class DropDownPropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropDown";
+
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropDownPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public DropDownPropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropdownlistMultiplePublishKeysPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropdownlistMultiplePublishKeysPropertyTypeMigrator.cs
@@ -1,0 +1,23 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value from the legacy <see cref="FromEditorAlias" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class DropdownlistMultiplePublishKeysPropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropdownlistMultiplePublishKeys";
+
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropdownlistMultiplePublishKeysPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public DropdownlistMultiplePublishKeysPropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropdownlistPublishingKeysPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/DropdownlistPublishingKeysPropertyTypeMigrator.cs
@@ -1,0 +1,23 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value from the legacy <see cref="FromEditorAlias" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// </summary>
+public sealed class DropdownlistPublishingKeysPropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    private const string FromEditorAlias = "Umbraco.DropdownlistPublishingKeys";
+
+    /// <inheritdoc />
+    protected override bool Multiple => true;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DropdownlistPublishingKeysPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public DropdownlistPublishingKeysPropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(FromEditorAlias, Constants.PropertyEditors.Aliases.DropDownListFlexible, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevalueArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevalueArtifactMigrator.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Semver;
+using Umbraco.Deploy.Core.Migrators;
+using Umbraco.Deploy.Infrastructure.Artifacts.Content;
+using Umbraco.Extensions;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the <see cref="ContentArtifactBase" /> property editor aliases to add a prefix to Umbraco 7 prevalue editors, triggering property type migrators.
+/// </summary>
+public class PrevalueArtifactMigrator : ArtifactMigratorBase<ContentArtifactBase>
+{
+    internal const string EditorAliasPrefix = "MigratePrevalue.";
+
+    private readonly string[] _editorAliases;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrevalueArtifactMigrator" /> class.
+    /// </summary>
+    public PrevalueArtifactMigrator()
+        : this(
+              Constants.PropertyEditors.Aliases.CheckBoxList,
+              Constants.PropertyEditors.Aliases.DropDownListFlexible,
+              Constants.PropertyEditors.Aliases.RadioButtonList)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrevalueArtifactMigrator" /> class.
+    /// </summary>
+    /// <param name="editorAliases">The editor aliases.</param>
+    protected PrevalueArtifactMigrator(params string[] editorAliases)
+    {
+        _editorAliases = editorAliases;
+
+        MaxVersion = new SemVersion(3, 0, 0);
+    }
+
+    /// <inheritdoc />
+    protected override bool CanMigrateType(Type type)
+        => type.Inherits<ContentArtifactBase>();
+
+    /// <inheritdoc />
+    protected override ContentArtifactBase? Migrate(ContentArtifactBase artifact)
+    {
+        // Add prefix to matching property editor aliases
+        artifact.PropertyEditorAliases = artifact.PropertyEditorAliases?.ToDictionary(x => x.Key, x => _editorAliases.Contains(x.Value) ? EditorAliasPrefix + x.Value : x.Value);
+
+        return artifact;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Deploy;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Serialization;
+using Umbraco.Deploy.Core.Migrators;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value containing prevalues (seperated by <see cref="Delimiter" />) from Umbraco 7 to a single value or JSON array.
+/// </summary>
+public abstract class PrevaluePropertyTypeMigratorBase : PropertyTypeMigratorBase
+{
+    private const string EditorAliasPrefix = PrevalueArtifactMigrator.EditorAliasPrefix;
+    private const string Delimiter = ";;";
+
+    private readonly IJsonSerializer _jsonSerializer;
+
+    /// <summary>
+    /// Gets a value indicating whether the property type stores multiple prevalues as a JSON array or single value.
+    /// </summary>
+    /// <value>
+    ///   <c>true</c> if multiple prevalues are stored as a JSON array; otherwise, <c>false</c>.
+    /// </value>
+    protected abstract bool Multiple { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrevaluePropertyTypeMigratorBase" /> class.
+    /// </summary>
+    /// <param name="editorAlias">The editor alias.</param>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    protected PrevaluePropertyTypeMigratorBase(string editorAlias, IJsonSerializer jsonSerializer)
+        : base(EditorAliasPrefix + editorAlias, editorAlias)
+        => _jsonSerializer = jsonSerializer;
+
+    /// <inheritdoc />
+    public override object? Migrate(IPropertyType propertyType, object? value, IDictionary<string, string> propertyEditorAliases, IContextCache contextCache)
+    {
+        if (value is not string stringValue)
+        {
+            return null;
+        }
+
+        var values = stringValue.Split(new[] { Delimiter }, StringSplitOptions.RemoveEmptyEntries);
+        if (values.Length == 0)
+        {
+            return null;
+        }
+
+        return Multiple
+            ? _jsonSerializer.Serialize(values)
+            : values[0];
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
@@ -28,10 +28,20 @@ public abstract class PrevaluePropertyTypeMigratorBase : PropertyTypeMigratorBas
     /// <summary>
     /// Initializes a new instance of the <see cref="PrevaluePropertyTypeMigratorBase" /> class.
     /// </summary>
-    /// <param name="editorAlias">The editor alias.</param>
+    /// <param name="editorAlias">The editor alias (without the prefix added by <see cref="PrevalueArtifactMigrator" />).</param>
     /// <param name="jsonSerializer">The JSON serializer.</param>
     protected PrevaluePropertyTypeMigratorBase(string editorAlias, IJsonSerializer jsonSerializer)
-        : base(EditorAliasPrefix + editorAlias, editorAlias)
+        : this(EditorAliasPrefix + editorAlias, editorAlias, jsonSerializer)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PrevaluePropertyTypeMigratorBase" /> class.
+    /// </summary>
+    /// <param name="fromEditorAlias">The editor alias to migrate from.</param>
+    /// <param name="toEditorAlias">The editor alias to migrate to.</param>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    protected PrevaluePropertyTypeMigratorBase(string fromEditorAlias, string toEditorAlias, IJsonSerializer jsonSerializer)
+        : base(fromEditorAlias, toEditorAlias)
         => _jsonSerializer = jsonSerializer;
 
     /// <inheritdoc />

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyValueArtifactMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyValueArtifactMigratorBase.cs
@@ -11,6 +11,7 @@ namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 /// <summary>
 /// Migrates the <see cref="PropertyValueWithSegments" /> using the specified editor alias from the <see cref="ContentArtifactBase" /> containing prevalues (seperated by <see cref="Delimiter" />) from Umbraco 7 to a single value or JSON array.
 /// </summary>
+[Obsolete("Migrating property values in an artifact migrator does not support nested/recursive properties. Use the PrevalueArtifactMigrator and property type migrators instead. This class will be removed in a future version.")]
 public abstract class PrevaluePropertyValueArtifactMigratorBase : PropertyValueArtifactMigratorBase
 {
     private const string Delimiter = ";;";

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/RadioButtonListPropertyTypeMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/RadioButtonListPropertyTypeMigrator.cs
@@ -1,0 +1,21 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Serialization;
+
+namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
+
+/// <summary>
+/// Migrates the property value using the <see cref="Constants.PropertyEditors.Aliases.RadioButtonList" /> editor containing prevalues (seperated by <see cref="PrevaluePropertyTypeMigratorBase.Delimiter" />) from Umbraco 7 to a single value.
+/// </summary>
+public sealed class RadioButtonListPropertyTypeMigrator : PrevaluePropertyTypeMigratorBase
+{
+    /// <inheritdoc />
+    protected override bool Multiple => false;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RadioButtonListPropertyTypeMigrator" /> class.
+    /// </summary>
+    /// <param name="jsonSerializer">The JSON serializer.</param>
+    public RadioButtonListPropertyTypeMigrator(IJsonSerializer jsonSerializer)
+        : base(Constants.PropertyEditors.Aliases.RadioButtonList, jsonSerializer)
+    { }
+}

--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/RadioButtonListPropertyValueArtifactMigrator.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/RadioButtonListPropertyValueArtifactMigrator.cs
@@ -1,3 +1,4 @@
+using System;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Serialization;
 using Umbraco.Cms.Core.Services;
@@ -7,8 +8,9 @@ using Umbraco.Deploy.Infrastructure.Artifacts.Content;
 namespace Umbraco.Deploy.Contrib.Migrators.Legacy;
 
 /// <summary>
-/// Migrates the <see cref="PropertyValueWithSegments" /> using the <see cref="Constants.PropertyEditors.Aliases.RadioButtonList" /> editor from the <see cref="ContentArtifactBase" /> containing prevalues (seperated by <see cref="PrevaluePropertyValueArtifactMigratorBase.Delimiter" />) from Umbraco 7 to a JSON array.
+/// Migrates the <see cref="PropertyValueWithSegments" /> using the <see cref="Constants.PropertyEditors.Aliases.RadioButtonList" /> editor from the <see cref="ContentArtifactBase" /> containing prevalues (seperated by <see cref="PrevaluePropertyValueArtifactMigratorBase.Delimiter" />) from Umbraco 7 to a single value.
 /// </summary>
+[Obsolete("Migrating property values in an artifact migrator does not support nested/recursive properties. Use the PrevalueArtifactMigrator and RadioButtonListPropertyTypeMigrator instead. This class will be removed in a future version.")]
 public class RadioButtonListPropertyValueArtifactMigrator : PrevaluePropertyValueArtifactMigratorBase
 {
     /// <inheritdoc />


### PR DESCRIPTION
Although PR https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/61 added support for migrating pre-value property values, it used artifact migrators inherited from `PrevaluePropertyValueArtifactMigratorBase` (using Deploys `PropertyValueArtifactMigratorBase`) that only migrates first level properties on the content artifacts. This was used because property type migrators are only executed when a property editor alias changes, but the following property editor aliases from Umbraco 7 are still used and are therefore unchanged:
- `Umbraco.CheckBoxList`
- `Umbraco.DropDown.Flexible`
- `Umbraco.RadioButtonList`

However, if these property editors are used in nested/recursive property values (like Nested Content), the values weren't migrated from the `;;` delimited string to either the single value (for Radio button list) or a JSON array (for Checkbox list and Dropdown list), causing JSON deserialization errors when opening/rendering the content (as reported on https://github.com/umbraco/Umbraco.Deploy.Issues/issues/234#issuecomment-2355409973).

To workaround this, I've added a `PrevalueArtifactMigrator` that adds a prefix to these property editor aliases on the content artifacts (if imported from Umbraco 7, adjusting the 'original' editor alias of the content when it was exported) and added property type migrators that does the property value migration going from:
- `MigratePrevalue.Umbraco.CheckBoxList` to `Umbraco.CheckBoxList`
- `MigratePrevalue.Umbraco.DropDown.Flexible` to `Umbraco.DropDown.Flexible`
- `MigratePrevalue.Umbraco.RadioButtonList` to `Umbraco.RadioButtonList`

Umbraco 7 also has some other legacy dropdown editors that have changed into `Umbraco.DropDown.Flexible`, which also requires property type migrators to migrate the property values:
- `Umbraco.DropDownMultiple`
- `Umbraco.DropDown`
- `Umbraco.DropdownlistMultiplePublishKeys`
- `Umbraco.DropdownlistPublishingKeys`

And finally, I noticed the `DropDownFlexibleDataTypeArtifactMigrator` was added after `DropDownDataTypeArtifactMigrator`, resulting in `Umbraco.DropDown` data types being correctly migrated into `Umbraco.DropDown.Flexible`, but then the already migrated data type configuration was migrated again, resulting in an empty configuration.

To easily register all property type migrators, I've added a `AddLegacyMigrators()` extension method, similar to the artifact migrators. This will need to be included in the documentation, as the property values otherwise won't get correctly migrated (without throwing exceptions during the import).

----------

For testing, I've created a basic Umbraco 7 export that contains a single page with a Nested Content property that has Dropdown lists, a Checkbox list and Radio button list: [export-Umbraco7-NestedContent-Prevalues.zip](https://github.com/user-attachments/files/17162923/export-Umbraco7-NestedContent-Prevalues.zip).

This ZIP archive can be imported to a v13 site using the following composer:


```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Deploy.Contrib.Migrators.Legacy;
using Umbraco.Deploy.Infrastructure.Migrators;

internal sealed class LegacyImportComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactTypeResolvers()
            .AddLegacyTypeResolver();

        builder.DeployArtifactMigrators()
            .AddLegacyMigrators()
            .Append<ElementTypeArtifactMigrator>()
            .Append<ReplaceNestedContentDataTypeArtifactMigrator>();

        builder.DeployPropertyTypeMigrators()
            .AddLegacyMigrators()
            .Append<NestedContentPropertyTypeMigrator>();
    }

    private sealed class ElementTypeArtifactMigrator : ElementTypeArtifactMigratorBase
    {
        public ElementTypeArtifactMigrator()
            : base("component")
        { }
    }
}
```