### PR TITLE
Migrate actual prevalue property value

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
+++ b/src/Umbraco.Deploy.Contrib/Migrators/Legacy/Content/PrevaluePropertyTypeMigratorBase.cs
@@ -48,7 +48,7 @@ public abstract class PrevaluePropertyTypeMigratorBase : PropertyTypeMigratorBas
 
     /// <inheritdoc />
     public override Task<object?> MigrateAsync(IPropertyType propertyType, object? value, IDictionary<string, string> propertyEditorAliases, IContextCache contextCache, CancellationToken cancellationToken = default)
-        => Task.FromResult(Migrate(propertyType));
+        => Task.FromResult(Migrate(value));
 
     private object? Migrate(object? value)
     {


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/umbraco/Umbraco.Deploy.Issues/issues/33#issuecomment-3370799539.

Although the original issue was fixed in https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/71, some refactoring in the v15 upgrade resulted in passing the property type instead of it's value (see PR https://github.com/umbraco/Umbraco.Deploy.Contrib/pull/69).