### PR TITLE
Ensure legacy migrators are inserted at the beginning of the collection

### DIFF
--- a/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/ArtifactMigratorCollectionBuilderExtensions.cs
@@ -6,42 +6,45 @@ namespace Umbraco.Extensions;
 public static class ArtifactMigratorCollectionBuilderExtensions
 {
     /// <summary>
-    /// Adds the legacy artifact migrators to allow importing from Umbraco 7.
+    /// Adds/inserts the legacy artifact migrators to allow importing from Umbraco 7.
     /// </summary>
     /// <param name="artifactMigratorCollectionBuilder">The artifact migrator collection builder.</param>
     /// <returns>
     /// The artifact migrator collection builder.
     /// </returns>
+    /// <remarks>
+    /// The legacy migrators are inserted at the beginning of the collection to ensure they run before any other migrators, including default Deploy migrators.
+    /// </remarks>
     public static ArtifactMigratorCollectionBuilder AddLegacyMigrators(this ArtifactMigratorCollectionBuilder artifactMigratorCollectionBuilder)
-        => artifactMigratorCollectionBuilder
+        => artifactMigratorCollectionBuilder.Insert(
             // Pre-values to configuration
-            .Append<PreValuesDataTypeArtifactJsonMigrator>()
+            typeof(PreValuesDataTypeArtifactJsonMigrator),
             // Release/expire dates to schedule
-            .Append<DocumentArtifactJsonMigrator>()
+            typeof(DocumentArtifactJsonMigrator),
             // Allowed at root and child content types to permissions
-            .Append<ContentTypeArtifactJsonMigrator>()
+            typeof(ContentTypeArtifactJsonMigrator),
             // Data types
-            .Append<CheckBoxListDataTypeArtifactMigrator>()
-            .Append<ColorPickerAliasDataTypeArtifactMigrator>()
-            .Append<ContentPicker2DataTypeArtifactMigrator>()
-            .Append<ContentPickerAliasDataTypeArtifactMigrator>()
-            .Append<DateDataTypeArtifactMigrator>()
-            .Append<DropDownFlexibleDataTypeArtifactMigrator>() // Ensure this is appended before other dropdown migrators to avoid duplicate migration
-            .Append<DropDownDataTypeArtifactMigrator>()
-            .Append<DropdownlistMultiplePublishKeysDataTypeArtifactMigrator>()
-            .Append<DropdownlistPublishingKeysDataTypeArtifactMigrator>()
-            .Append<DropDownMultipleDataTypeArtifactMigrator>()
-            .Append<MediaPicker2DataTypeArtifactMigrator>()
-            .Append<MemberPicker2DataTypeArtifactMigrator>()
-            .Append<MultiNodeTreePicker2DataTypeArtifactMigrator>()
-            .Append<MultipleMediaPickerDataTypeArtifactMigrator>()
-            .Append<NoEditDataTypeArtifactMigrator>()
-            .Append<RadioButtonListDataTypeArtifactMigrator>()
-            .Append<RelatedLinks2DataTypeArtifactMigrator>()
-            .Append<RelatedLinksDataTypeArtifactMigrator>()
-            .Append<TextboxDataTypeArtifactMigrator>()
-            .Append<TextboxMultipleDataTypeArtifactMigrator>()
-            .Append<TinyMCEv3DataTypeArtifactMigrator>()
+            typeof(CheckBoxListDataTypeArtifactMigrator),
+            typeof(ColorPickerAliasDataTypeArtifactMigrator),
+            typeof(ContentPicker2DataTypeArtifactMigrator),
+            typeof(ContentPickerAliasDataTypeArtifactMigrator),
+            typeof(DateDataTypeArtifactMigrator),
+            typeof(DropDownFlexibleDataTypeArtifactMigrator), // Ensure this is appended before other dropdown migrators to avoid duplicate migration
+            typeof(DropDownDataTypeArtifactMigrator),
+            typeof(DropdownlistMultiplePublishKeysDataTypeArtifactMigrator),
+            typeof(DropdownlistPublishingKeysDataTypeArtifactMigrator),
+            typeof(DropDownMultipleDataTypeArtifactMigrator),
+            typeof(MediaPicker2DataTypeArtifactMigrator),
+            typeof(MemberPicker2DataTypeArtifactMigrator),
+            typeof(MultiNodeTreePicker2DataTypeArtifactMigrator),
+            typeof(MultipleMediaPickerDataTypeArtifactMigrator),
+            typeof(NoEditDataTypeArtifactMigrator),
+            typeof(RadioButtonListDataTypeArtifactMigrator),
+            typeof(RelatedLinks2DataTypeArtifactMigrator),
+            typeof(RelatedLinksDataTypeArtifactMigrator),
+            typeof(TextboxDataTypeArtifactMigrator),
+            typeof(TextboxMultipleDataTypeArtifactMigrator),
+            typeof(TinyMCEv3DataTypeArtifactMigrator),
             // Add prefixes to pre-value property editor aliases, triggering property type migrators
-            .Append<PrevalueArtifactMigrator>();
+            typeof(PrevalueArtifactMigrator));
 }

--- a/src/Umbraco.Deploy.Contrib/Extensions/ArtifactTypeResolverCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/ArtifactTypeResolverCollectionBuilderExtensions.cs
@@ -6,12 +6,15 @@ namespace Umbraco.Extensions;
 public static class ArtifactTypeResolverCollectionBuilderExtensions
 {
     /// <summary>
-    /// Adds the legacy artifact type resolver to allow importing from Umbraco 7.
+    /// Adds/inserts the legacy artifact type resolver to allow importing from Umbraco 7.
     /// </summary>
     /// <param name="artifactTypeResolverCollectionBuilder">The artifact type resolver collection builder.</param>
     /// <returns>
     /// The artifact type resolver collection builder.
     /// </returns>
+    /// <remarks>
+    /// The legacy artifact type resolver is inserted at the beginning of the collection to ensure it runs before any other resolvers.
+    /// </remarks>
     public static ArtifactTypeResolverCollectionBuilder AddLegacyTypeResolver(this ArtifactTypeResolverCollectionBuilder artifactTypeResolverCollectionBuilder)
-        => artifactTypeResolverCollectionBuilder.Append<LegacyArtifactTypeResolver>();
+        => artifactTypeResolverCollectionBuilder.Insert<LegacyArtifactTypeResolver>();
 }

--- a/src/Umbraco.Deploy.Contrib/Extensions/OrderedCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/OrderedCollectionBuilderExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Composing;
+using Umbraco.Deploy.Core.Migrators;
+
+namespace Umbraco.Extensions;
+
+internal static class OrderedCollectionBuilderExtensions
+{
+    public static ArtifactMigratorCollectionBuilder Insert(this ArtifactMigratorCollectionBuilder builder, params IEnumerable<Type> types)
+        => Insert(builder, 0, types);
+
+    public static ArtifactMigratorCollectionBuilder Insert(this ArtifactMigratorCollectionBuilder builder, int index, params IEnumerable<Type> types)
+        => Insert<ArtifactMigratorCollectionBuilder, ArtifactMigratorCollection, IArtifactMigrator>(builder, index, types);
+
+    public static PropertyTypeMigratorCollectionBuilder Insert(this PropertyTypeMigratorCollectionBuilder builder, params IEnumerable<Type> types)
+        => Insert(builder, 0, types);
+
+    public static PropertyTypeMigratorCollectionBuilder Insert(this PropertyTypeMigratorCollectionBuilder builder, int index, params IEnumerable<Type> types)
+        => Insert<PropertyTypeMigratorCollectionBuilder, PropertyTypeMigratorCollection, IPropertyTypeMigrator>(builder, index, types);
+
+    private static TBuilder Insert<TBuilder, TCollection, TItem>(TBuilder builder, int index, params IEnumerable<Type> types)
+        where TBuilder : OrderedCollectionBuilderBase<TBuilder, TCollection, TItem>
+        where TCollection : class, IBuilderCollection<TItem>
+    {
+        foreach (var type in types)
+        {
+            builder.Insert(index, type);
+
+            // Insert next type after the current one
+            index++;
+        }
+
+        return builder;
+    }
+}

--- a/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
+++ b/src/Umbraco.Deploy.Contrib/Extensions/PropertyTypeMigratorCollectionBuilderExtensions.cs
@@ -6,19 +6,22 @@ namespace Umbraco.Extensions;
 public static class PropertyTypeMigratorCollectionBuilderExtensions
 {
     /// <summary>
-    /// Adds the legacy property type migrators to allow importing from Umbraco 7.
+    /// Adds/inserts the legacy property type migrators to allow importing from Umbraco 7.
     /// </summary>
     /// <returns>
     /// The property type migrator collection builder.
     /// </returns>
+    /// <remarks>
+    /// The legacy migrators are inserted at the beginning of the collection to ensure they run before any other migrators, including default Deploy migrators.
+    /// </remarks>
     public static PropertyTypeMigratorCollectionBuilder AddLegacyMigrators(this PropertyTypeMigratorCollectionBuilder propertyTypeMigratorCollectionBuilder)
-        => propertyTypeMigratorCollectionBuilder
+        => propertyTypeMigratorCollectionBuilder.Insert(
             // Pre-values to a single value or JSON array
-            .Append<CheckBoxListPropertyTypeMigrator>()
-            .Append<DropDownPropertyTypeMigrator>()
-            .Append<DropDownListFlexiblePropertyTypeMigrator>()
-            .Append<DropdownlistMultiplePublishKeysPropertyTypeMigrator>()
-            .Append<DropdownlistPublishingKeysPropertyTypeMigrator>()
-            .Append<DropDownMultiplePropertyTypeMigrator>()
-            .Append<RadioButtonListPropertyTypeMigrator>();
+            typeof(CheckBoxListPropertyTypeMigrator),
+            typeof(DropDownPropertyTypeMigrator),
+            typeof(DropDownListFlexiblePropertyTypeMigrator),
+            typeof(DropdownlistMultiplePublishKeysPropertyTypeMigrator),
+            typeof(DropdownlistPublishingKeysPropertyTypeMigrator),
+            typeof(DropDownMultiplePropertyTypeMigrator),
+            typeof(RadioButtonListPropertyTypeMigrator));
 }


### PR DESCRIPTION
While testing [importing legacy Umbraco 7 content and schema](https://docs.umbraco.com/umbraco-deploy/deployment-workflow/import-export/import-export-v7#importing-umbraco-7-content-and-schema) into v16, I noticed it's become a little harder in recent versions to ensure the migrators are added in the correct order, because Deploy now adds quite a few migrators by default (e.g. to migrate property editors that were removed in v14, like Nested Content and Grid layout).

To ensure the legacy migrators are added before the default Deploy ones, you need to add them in a composer that runs before the Deploy one (which is different between Deploy Cloud and OnPrem). It's also important to add your own migrators after the Deploy ones (especially migrators like `ReplaceUnknownEditorDataTypeArtifactMigrator`, so Nested Content isn't replaced with a label), requiring you to use different composers:

```c#
using Umbraco.Cms.Core.Composing;
using Umbraco.Deploy.Cloud;
using Umbraco.Deploy.Infrastructure.Migrators;

[ComposeBefore(typeof(UmbracoDeployCloudComposer))]
//[ComposeBefore(typeof(UmbracoDeployOnPremComposer))]
internal sealed class LegacyDeployMigratorsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactTypeResolvers().AddLegacyTypeResolver();
        builder.DeployArtifactMigrators().AddLegacyMigrators();
        builder.DeployPropertyTypeMigrators().AddLegacyMigrators();
    }
}

[ComposeAfter(typeof(UmbracoDeployCloudComposer))]
//[ComposeAfter(typeof(UmbracoDeployOnPremComposer))]
internal sealed class DeployMigratorsComposer : IComposer
{
    public void Compose(IUmbracoBuilder builder)
    {
        builder.DeployArtifactMigrators()
            .Append<ReplaceMediaPickerDataTypeArtifactMigrator>()
            .Append<ReplaceNestedContentDataTypeArtifactMigrator>()
            .Append<ReplaceUnknownEditorDataTypeArtifactMigrator>();

        builder.DeployPropertyTypeMigrators()
            .Append<MediaPickerPropertyTypeMigrator>()
            .Append<NestedContentPropertyTypeMigrator>();
    }
}
```

To fix this, I've updated the `AddLegacyMigrators()` methods to insert the required artifact and property type migrators (and aligned AddLegacyTypeResolver()` to insert as well).